### PR TITLE
Fix xiaohongshu image env fallback

### DIFF
--- a/skills/xiaohongshu/SKILL.md
+++ b/skills/xiaohongshu/SKILL.md
@@ -265,6 +265,8 @@ print(f'已保存 output.png (1080x1440)')
 
 同样先调用 UI/UX Pro Max 获取配色和风格方向，再传给图片生成脚本：
 
+运行前设置 `ATLAS_API_KEY`/`LLM_API_KEY`；如需从文件读取，显式传 `--env-file` 或设置 `XHS_ENV_FILE`。
+
 ```bash
 python3 ~/.claude/skills/xiaohongshu/scripts/generate_image.py "{prompt}" --ratio 3:4 --num 1 --output ./images
 ```

--- a/skills/xiaohongshu/scripts/generate_image.py
+++ b/skills/xiaohongshu/scripts/generate_image.py
@@ -11,49 +11,69 @@ import time
 import argparse
 import requests
 from pathlib import Path
+from typing import Dict, Optional, Tuple
 
-# 默认配置文件路径
-DEFAULT_ENV_PATH = "/Users/lifcc/Desktop/code/work/mutil-om/om-generator/.env"
+DEFAULT_API_BASE = "https://api.atlascloud.ai/v1"
+ENV_FILE_ENV_VAR = "XHS_ENV_FILE"
 
 
-def load_env_file(env_path: str) -> dict:
+class ConfigError(RuntimeError):
+    """Raised when required API configuration is missing or invalid."""
+
+
+def load_env_file(env_path: str) -> Dict[str, str]:
     """从.env文件加载配置"""
+    config_path = Path(env_path).expanduser()
+    if not config_path.is_file():
+        raise ConfigError(f"配置文件不存在: {config_path}")
+
     config = {}
-    if Path(env_path).exists():
-        with open(env_path) as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith("#") and "=" in line:
-                    key, value = line.split("=", 1)
-                    # 去除行内注释 (# 后面的内容)
-                    if " #" in value:
-                        value = value.split(" #")[0]
-                    # 去除可能的引号和空白
-                    value = value.strip().strip('"').strip("'")
-                    config[key.strip()] = value
+    with open(config_path) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, value = line.split("=", 1)
+                # 去除行内注释 (# 后面的内容)
+                if " #" in value:
+                    value = value.split(" #")[0]
+                # 去除可能的引号和空白
+                value = value.strip().strip('"').strip("'")
+                config[key.strip()] = value
     return config
 
 
-def get_config():
+def resolve_config(env_file: Optional[str] = None) -> Tuple[str, str]:
     """获取API配置"""
     # 优先从环境变量获取
     api_key = os.environ.get("ATLAS_API_KEY") or os.environ.get("LLM_API_KEY")
     api_base = os.environ.get("ATLAS_API_BASE") or os.environ.get("LLM_API_BASE")
 
-    # 如果环境变量没有，从默认.env文件读取
-    if not api_key or not api_base:
-        env_config = load_env_file(DEFAULT_ENV_PATH)
-        api_key = api_key or env_config.get("LLM_API_KEY")
-        api_base = api_base or env_config.get("LLM_API_BASE")
+    # 只在显式指定时读取.env文件，避免从作者本机路径或隐式文件读取凭据
+    explicit_env_file = env_file or os.environ.get(ENV_FILE_ENV_VAR)
+    if explicit_env_file and (not api_key or not api_base):
+        env_config = load_env_file(explicit_env_file)
+        api_key = api_key or env_config.get("ATLAS_API_KEY") or env_config.get("LLM_API_KEY")
+        api_base = api_base or env_config.get("ATLAS_API_BASE") or env_config.get("LLM_API_BASE")
 
     if not api_key:
-        print("错误: 未找到 API Key，请设置 LLM_API_KEY 环境变量或检查 .env 文件", file=sys.stderr)
-        sys.exit(1)
+        raise ConfigError(
+            "未找到 API Key，请设置 ATLAS_API_KEY/LLM_API_KEY，"
+            "或通过 --env-file/XHS_ENV_FILE 显式指定配置文件"
+        )
 
     if not api_base:
-        api_base = "https://api.atlascloud.ai/v1"
+        api_base = DEFAULT_API_BASE
 
     return api_key, api_base
+
+
+def get_config(env_file: Optional[str] = None) -> Tuple[str, str]:
+    """获取API配置，CLI入口使用清晰错误信息退出。"""
+    try:
+        return resolve_config(env_file)
+    except ConfigError as exc:
+        sys.stderr.write(f"错误: {exc}\n")
+        sys.exit(1)
 
 
 def generate_image(
@@ -61,7 +81,8 @@ def generate_image(
     aspect_ratio: str = "3:4",
     num_images: int = 1,
     output_dir: str = None,
-    model: str = "google/nano-banana/text-to-image"
+    model: str = "google/nano-banana/text-to-image",
+    env_file: Optional[str] = None
 ):
     """
     生成图片
@@ -72,8 +93,9 @@ def generate_image(
         num_images: 生成数量
         output_dir: 输出目录
         model: 模型名称
+        env_file: 显式指定的.env配置文件路径
     """
-    api_key, api_base = get_config()
+    api_key, api_base = get_config(env_file)
 
     # Atlas Cloud 图片生成 endpoint
     # 将 /v1 替换为完整的图片生成路径
@@ -194,9 +216,10 @@ def main():
                             "google/nano-banana-pro/text-to-image"
                         ],
                         help="模型 (默认: nano-banana)")
+    parser.add_argument("--env-file", help="显式指定 .env 配置文件；也可设置 XHS_ENV_FILE")
 
     args = parser.parse_args()
-    generate_image(args.prompt, args.ratio, args.num, args.output, args.model)
+    generate_image(args.prompt, args.ratio, args.num, args.output, args.model, args.env_file)
 
 
 if __name__ == "__main__":

--- a/skills/xiaohongshu/scripts/generate_image.py
+++ b/skills/xiaohongshu/scripts/generate_image.py
@@ -50,8 +50,8 @@ def resolve_config(env_file: Optional[str] = None) -> Tuple[str, str]:
 
     # 只在显式指定时读取.env文件，避免从作者本机路径或隐式文件读取凭据
     explicit_env_file = env_file or os.environ.get(ENV_FILE_ENV_VAR)
-    if explicit_env_file and (not api_key or not api_base):
-        env_config = load_env_file(explicit_env_file)
+    env_config = load_env_file(explicit_env_file) if explicit_env_file else {}
+    if env_config and (not api_key or not api_base):
         api_key = api_key or env_config.get("ATLAS_API_KEY") or env_config.get("LLM_API_KEY")
         api_base = api_base or env_config.get("ATLAS_API_BASE") or env_config.get("LLM_API_BASE")
 

--- a/tests/test_xiaohongshu_generate_image_config.py
+++ b/tests/test_xiaohongshu_generate_image_config.py
@@ -1,0 +1,87 @@
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "skills" / "xiaohongshu" / "scripts" / "generate_image.py"
+TRACKED_ENV = [
+    "ATLAS_API_KEY",
+    "LLM_API_KEY",
+    "ATLAS_API_BASE",
+    "LLM_API_BASE",
+    "XHS_ENV_FILE",
+]
+
+
+def load_script_module():
+    spec = importlib.util.spec_from_file_location("generate_image_script", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class XiaohongshuGenerateImageConfigTests(unittest.TestCase):
+    def setUp(self):
+        self.module = load_script_module()
+        self.original_env = {name: os.environ.get(name) for name in TRACKED_ENV}
+        for name in TRACKED_ENV:
+            os.environ.pop(name, None)
+
+    def tearDown(self):
+        for name in TRACKED_ENV:
+            os.environ.pop(name, None)
+            if self.original_env[name] is not None:
+                os.environ[name] = self.original_env[name]
+
+    def test_env_vars_are_used_without_env_file(self):
+        os.environ["ATLAS_API_KEY"] = "atlas-key"
+        os.environ["ATLAS_API_BASE"] = "https://atlas.example/v1"
+
+        self.assertEqual(
+            self.module.resolve_config(),
+            ("atlas-key", "https://atlas.example/v1"),
+        )
+
+    def test_missing_credentials_do_not_read_implicit_env_file(self):
+        with self.assertRaises(self.module.ConfigError) as context:
+            self.module.resolve_config()
+
+        self.assertIn("--env-file/XHS_ENV_FILE", str(context.exception))
+
+    def test_explicit_env_file_is_loaded(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_path = Path(tmpdir) / ".env"
+            env_path.write_text(
+                "LLM_API_KEY='file-key'\n"
+                "LLM_API_BASE=https://file.example/v1 # local comment\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                self.module.resolve_config(str(env_path)),
+                ("file-key", "https://file.example/v1"),
+            )
+
+    def test_xhs_env_file_is_loaded(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_path = Path(tmpdir) / ".env"
+            env_path.write_text("ATLAS_API_KEY=file-key\n", encoding="utf-8")
+            os.environ["XHS_ENV_FILE"] = str(env_path)
+
+            self.assertEqual(
+                self.module.resolve_config(),
+                ("file-key", self.module.DEFAULT_API_BASE),
+            )
+
+    def test_missing_explicit_env_file_fails_loudly(self):
+        with self.assertRaises(self.module.ConfigError) as context:
+            self.module.resolve_config("/tmp/xhs-missing-env-file")
+
+        self.assertIn("配置文件不存在", str(context.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_xiaohongshu_generate_image_config.py
+++ b/tests/test_xiaohongshu_generate_image_config.py
@@ -1,6 +1,8 @@
 import importlib.util
 import os
+import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 
@@ -16,10 +18,35 @@ TRACKED_ENV = [
 ]
 
 
+class StubRequestException(Exception):
+    """Minimal requests exception type used by the config-only test loader."""
+
+
+class StubTimeout(StubRequestException):
+    """Minimal requests timeout type used by the config-only test loader."""
+
+
+def build_requests_stub():
+    requests_stub = types.ModuleType("requests")
+    requests_stub.exceptions = types.SimpleNamespace(
+        RequestException=StubRequestException,
+        Timeout=StubTimeout,
+    )
+    return requests_stub
+
+
 def load_script_module():
     spec = importlib.util.spec_from_file_location("generate_image_script", SCRIPT_PATH)
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    original_requests = sys.modules.get("requests")
+    sys.modules["requests"] = build_requests_stub()
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if original_requests is None:
+            sys.modules.pop("requests", None)
+        else:
+            sys.modules["requests"] = original_requests
     return module
 
 
@@ -79,6 +106,17 @@ class XiaohongshuGenerateImageConfigTests(unittest.TestCase):
     def test_missing_explicit_env_file_fails_loudly(self):
         with self.assertRaises(self.module.ConfigError) as context:
             self.module.resolve_config("/tmp/xhs-missing-env-file")
+
+        self.assertIn("配置文件不存在", str(context.exception))
+
+    def test_missing_explicit_env_file_fails_even_when_env_vars_are_complete(self):
+        os.environ["ATLAS_API_KEY"] = "atlas-key"
+        os.environ["ATLAS_API_BASE"] = "https://atlas.example/v1"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_path = Path(tmpdir) / "missing.env"
+            with self.assertRaises(self.module.ConfigError) as context:
+                self.module.resolve_config(str(missing_path))
 
         self.assertIn("配置文件不存在", str(context.exception))
 


### PR DESCRIPTION
## Summary
- Remove the author-local absolute .env fallback from the xiaohongshu image generator.
- Load .env files only when explicitly requested via --env-file or XHS_ENV_FILE, with loud errors for missing files or credentials.
- Document the credential contract and add focused config tests.

## Validation
- python3 -B -m unittest tests.test_xiaohongshu_generate_image_config
- python3 scripts/validate_skills.py --check
- python3 -B skills/xiaohongshu/scripts/generate_image.py --help
- git diff --check

Closes #9