### PR TITLE
fix(skill-creator): reject symlinks when packaging

### DIFF
--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -24,6 +24,15 @@ EXCLUDE_FILES = {".DS_Store"}
 ROOT_EXCLUDE_DIRS = {"evals"}
 
 
+def is_relative_to(path: Path, directory: Path) -> bool:
+    """Return whether path is contained by directory after resolution."""
+    try:
+        path.relative_to(directory)
+        return True
+    except ValueError:
+        return False
+
+
 def should_exclude(rel_path: Path) -> bool:
     """Check if a path should be excluded from packaging."""
     parts = rel_path.parts
@@ -37,6 +46,27 @@ def should_exclude(rel_path: Path) -> bool:
     if name in EXCLUDE_FILES:
         return True
     return any(fnmatch.fnmatch(name, pat) for pat in EXCLUDE_GLOBS)
+
+
+def collect_package_entries(skill_path: Path):
+    """Collect package entries after rejecting unsafe filesystem paths."""
+    entries = []
+
+    for file_path in skill_path.rglob('*'):
+        arcname = file_path.relative_to(skill_path.parent)
+        if should_exclude(arcname):
+            continue
+        if file_path.is_symlink():
+            raise ValueError(f"Symlinks are not allowed in skill packages: {arcname}")
+        if not file_path.is_file():
+            continue
+
+        resolved_file = file_path.resolve(strict=True)
+        if not is_relative_to(resolved_file, skill_path):
+            raise ValueError(f"Refusing to package file outside skill folder: {arcname}")
+        entries.append((file_path, arcname))
+
+    return entries
 
 
 def package_skill(skill_path, output_dir=None):
@@ -88,15 +118,9 @@ def package_skill(skill_path, output_dir=None):
 
     # Create the .skill file (zip format)
     try:
+        package_entries = collect_package_entries(skill_path)
         with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
-            # Walk through the skill directory, excluding build artifacts
-            for file_path in skill_path.rglob('*'):
-                if not file_path.is_file():
-                    continue
-                arcname = file_path.relative_to(skill_path.parent)
-                if should_exclude(arcname):
-                    print(f"  Skipped: {arcname}")
-                    continue
+            for file_path, arcname in package_entries:
                 zipf.write(file_path, arcname)
                 print(f"  Added: {arcname}")
 

--- a/tests/test_package_skill.py
+++ b/tests/test_package_skill.py
@@ -1,0 +1,73 @@
+import io
+import sys
+import unittest
+import zipfile
+from contextlib import redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_CREATOR_ROOT = REPO_ROOT / "skills" / "skill-creator"
+sys.path.insert(0, str(SKILL_CREATOR_ROOT))
+
+from scripts.package_skill import package_skill  # noqa: E402
+
+
+class PackageSkillTests(unittest.TestCase):
+    def make_skill(self, root: Path) -> Path:
+        skill_path = root / "safe-skill"
+        skill_path.mkdir()
+        (skill_path / "SKILL.md").write_text(
+            "---\n"
+            "name: safe-skill\n"
+            "description: A safe skill for packager tests.\n"
+            "---\n\n"
+            "# Safe Skill\n",
+            encoding="utf-8",
+        )
+        return skill_path
+
+    def test_packages_regular_files(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            skill_path = self.make_skill(root)
+            (skill_path / "references").mkdir()
+            (skill_path / "references" / "notes.md").write_text("notes", encoding="utf-8")
+            output_dir = root / "dist"
+
+            with redirect_stdout(io.StringIO()):
+                archive_path = package_skill(skill_path, output_dir)
+
+            self.assertEqual(archive_path, (output_dir / "safe-skill.skill").resolve())
+            self.assertTrue(archive_path.exists())
+            with zipfile.ZipFile(archive_path) as archive:
+                self.assertEqual(
+                    sorted(archive.namelist()),
+                    ["safe-skill/SKILL.md", "safe-skill/references/notes.md"],
+                )
+
+    def test_rejects_symlink_to_file_outside_skill(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            skill_path = self.make_skill(root)
+            outside_file = root / "outside-secret.txt"
+            outside_file.write_text("SECRET_TOKEN=leaked", encoding="utf-8")
+            symlink_path = skill_path / "secret-link.txt"
+            try:
+                symlink_path.symlink_to(outside_file)
+            except OSError as exc:
+                self.skipTest(f"symlinks are not available: {exc}")
+
+            output_dir = root / "dist"
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                archive_path = package_skill(skill_path, output_dir)
+
+            self.assertIsNone(archive_path)
+            self.assertIn("Symlinks are not allowed", stdout.getvalue())
+            self.assertFalse((output_dir / "safe-skill.skill").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject symlink entries before writing .skill archives
- Resolve package candidates and ensure they remain inside the skill directory
- Add unittest coverage for normal packaging and symlink escape rejection

Fixes #8

## Validation
- python3 -m unittest discover
- python3 -m unittest tests.test_package_skill
- python3 scripts/validate_skills.py
- python3 -m scripts.package_skill . /tmp/claude-arsenal-package-test (from skills/skill-creator)