### PR TITLE
Fix remote maintenance script injection risks

### DIFF
--- a/skills/cliproxy-newapi-stack/scripts/add_codex_account.sh
+++ b/skills/cliproxy-newapi-stack/scripts/add_codex_account.sh
@@ -11,6 +11,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=skills/cliproxy-newapi-stack/scripts/lib/validation.sh
+. "$SCRIPT_DIR/lib/validation.sh"
+
 : "${PROVIDER:=codex}"   # one of: codex|claude|qwen|iflow|antigravity|gemini
 : "${SSH_TARGET:?SSH_TARGET required}"
 : "${SSH_KEY:=$HOME/.ssh/id_ed25519}"
@@ -28,15 +32,18 @@ case "$PROVIDER" in
   *) echo "unknown PROVIDER=$PROVIDER" >&2; exit 2 ;;
 esac
 
+require_safe_ssh_target SSH_TARGET "$SSH_TARGET"
+require_absolute_safe_path REMOTE_AUTH_DIR "$REMOTE_AUTH_DIR"
+
 mkdir -p "$LOCAL_AUTH_DIR"
 echo ">> Capturing existing credentials before login"
-before=$(ls -1 "$LOCAL_AUTH_DIR"/${PROVIDER}-*.json 2>/dev/null | sort || true)
+before=$(find "$LOCAL_AUTH_DIR" -maxdepth 1 -type f -name "${PROVIDER}-*.json" -print | sort)
 
 echo ">> Run OAuth in browser for the NEW account (logout/incognito as needed)"
 ( cd "$CLIPROXY_LOCAL" && go run ./cmd/server "$FLAG" -config config.yaml )
 
-after=$(ls -1 "$LOCAL_AUTH_DIR"/${PROVIDER}-*.json 2>/dev/null | sort || true)
-new=$(comm -13 <(echo "$before") <(echo "$after") || true)
+after=$(find "$LOCAL_AUTH_DIR" -maxdepth 1 -type f -name "${PROVIDER}-*.json" -print | sort)
+new=$(comm -13 <(printf '%s\n' "$before" | sed '/^$/d') <(printf '%s\n' "$after" | sed '/^$/d') || true)
 
 if [ -z "$new" ]; then
   echo "no new credential file detected; aborting"
@@ -47,14 +54,29 @@ echo ">> New credential(s):"
 echo "$new"
 
 echo ">> Syncing to $SSH_TARGET:$REMOTE_AUTH_DIR"
-ssh -i "$SSH_KEY" "$SSH_TARGET" "mkdir -p '$REMOTE_AUTH_DIR'"
+ssh -i "$SSH_KEY" -- "$SSH_TARGET" bash -s -- "$REMOTE_AUTH_DIR" <<'REMOTE'
+  set -euo pipefail
+  remote_auth_dir=$1
+  mkdir -p -- "$remote_auth_dir"
+REMOTE
 while IFS= read -r f; do
-  [ -n "$f" ] && scp -i "$SSH_KEY" "$f" "$SSH_TARGET:$REMOTE_AUTH_DIR/"
+  [ -n "$f" ] && scp -i "$SSH_KEY" -- "$f" "$SSH_TARGET:$REMOTE_AUTH_DIR/"
 done <<< "$new"
 
 echo ">> Watcher should auto-load. Tailing log for confirmation..."
-ssh -i "$SSH_KEY" "$SSH_TARGET" \
+ssh -i "$SSH_KEY" -- "$SSH_TARGET" \
   "tail -n 100 /root/CLIProxyAPI/cli-proxy-api.log | grep -iE 'auth file changed|added' | tail -n 5"
 
 echo ">> Listing remote credentials"
-ssh -i "$SSH_KEY" "$SSH_TARGET" "ls -l '$REMOTE_AUTH_DIR'/${PROVIDER}-*.json"
+ssh -i "$SSH_KEY" -- "$SSH_TARGET" bash -s -- "$REMOTE_AUTH_DIR" "$PROVIDER" <<'REMOTE'
+  set -euo pipefail
+  remote_auth_dir=$1
+  provider=$2
+  shopt -s nullglob
+  files=("${remote_auth_dir}/${provider}-"*.json)
+  if ((${#files[@]} == 0)); then
+    echo "no remote credentials found for provider ${provider}" >&2
+    exit 1
+  fi
+  ls -l -- "${files[@]}"
+REMOTE

--- a/skills/cliproxy-newapi-stack/scripts/deploy_newapi.sh
+++ b/skills/cliproxy-newapi-stack/scripts/deploy_newapi.sh
@@ -8,6 +8,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=skills/cliproxy-newapi-stack/scripts/lib/validation.sh
+. "$SCRIPT_DIR/lib/validation.sh"
+
 : "${SSH_TARGET:?SSH_TARGET required (e.g. root@1.2.3.4)}"
 : "${SSH_KEY:=$HOME/.ssh/id_ed25519}"
 : "${PORT:=8200}"
@@ -16,27 +20,40 @@ set -euo pipefail
 : "${IMAGE:=calciumion/new-api:latest}"
 : "${TZ_VAL:=Asia/Shanghai}"
 
-ssh -i "$SSH_KEY" "$SSH_TARGET" "
-  set -e
+require_safe_ssh_target SSH_TARGET "$SSH_TARGET"
+require_port PORT "$PORT"
+require_absolute_safe_path DATA_DIR "$DATA_DIR"
+require_absolute_safe_path LOGS_DIR "$LOGS_DIR"
+require_safe_docker_image IMAGE "$IMAGE"
+require_safe_timezone TZ_VAL "$TZ_VAL"
+
+ssh -i "$SSH_KEY" -- "$SSH_TARGET" bash -s -- "$PORT" "$DATA_DIR" "$LOGS_DIR" "$IMAGE" "$TZ_VAL" <<'REMOTE'
+  set -euo pipefail
+  port=$1
+  data_dir=$2
+  logs_dir=$3
+  image=$4
+  tz_val=$5
+
   command -v docker >/dev/null || { apt-get update && apt-get install -y docker.io; }
   systemctl enable --now docker
-  mkdir -p '$DATA_DIR' '$LOGS_DIR'
-  docker pull '$IMAGE'
+  mkdir -p -- "$data_dir" "$logs_dir"
+  docker pull "$image"
   docker rm -f new-api 2>/dev/null || true
   docker run -d --name new-api --restart unless-stopped \
-    -p '$PORT':3000 \
-    -e TZ='$TZ_VAL' \
-    -v '$DATA_DIR':/data \
-    -v '$LOGS_DIR':/app/logs \
-    '$IMAGE'
+    -p "${port}:3000" \
+    -e "TZ=${tz_val}" \
+    -v "${data_dir}:/data" \
+    -v "${logs_dir}:/app/logs" \
+    "$image"
   for i in 1 2 3 4 5 6 7 8 9 10; do
     sleep 2
-    if curl -fsS -o /dev/null http://127.0.0.1:'$PORT'/api/setup; then
-      echo NewAPI ready on port $PORT
+    if curl -fsS -o /dev/null "http://127.0.0.1:${port}/api/setup"; then
+      echo "NewAPI ready on port ${port}"
       exit 0
     fi
   done
   echo NewAPI did not become ready, recent logs: >&2
   docker logs --tail 50 new-api >&2
   exit 1
-"
+REMOTE

--- a/skills/cliproxy-newapi-stack/scripts/lib/validation.sh
+++ b/skills/cliproxy-newapi-stack/scripts/lib/validation.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 2
+}
+
+require_uint() {
+  local name=$1
+  local value=$2
+
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    die "$name must be an unsigned integer"
+  fi
+}
+
+require_positive_uint() {
+  local name=$1
+  local value=$2
+
+  require_uint "$name" "$value"
+  if (( 10#$value < 1 )); then
+    die "$name must be greater than zero"
+  fi
+}
+
+require_port() {
+  local name=$1
+  local value=$2
+
+  require_uint "$name" "$value"
+  if (( 10#$value < 1 || 10#$value > 65535 )); then
+    die "$name must be between 1 and 65535"
+  fi
+}
+
+require_absolute_safe_path() {
+  local name=$1
+  local value=$2
+
+  if [[ -z "$value" || "$value" != /* ]]; then
+    die "$name must be an absolute path"
+  fi
+  if [[ ! "$value" =~ ^/[A-Za-z0-9._/:+-]+$ ]]; then
+    die "$name contains unsupported characters"
+  fi
+  if [[ "$value" == *"/../"* || "$value" == *"/.." || "$value" == *"//"* ]]; then
+    die "$name must not contain path traversal or duplicate slashes"
+  fi
+}
+
+require_safe_container_name() {
+  local name=$1
+  local value=$2
+
+  if [[ "$value" == -* || ! "$value" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]*$ ]]; then
+    die "$name must be a Docker container name"
+  fi
+}
+
+require_safe_docker_image() {
+  local name=$1
+  local value=$2
+
+  if [[ "$value" == -* || ! "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._/:@-]*$ ]]; then
+    die "$name must be a Docker image reference"
+  fi
+}
+
+require_safe_host() {
+  local name=$1
+  local value=$2
+
+  if [[ "$value" == -* || ! "$value" =~ ^[A-Za-z0-9._:-]+$ ]]; then
+    die "$name must be a host name or IP address"
+  fi
+}
+
+require_safe_model_name() {
+  local name=$1
+  local value=$2
+
+  if [[ "$value" == -* || ! "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._:+/@-]*$ ]]; then
+    die "$name must be a model name"
+  fi
+}
+
+require_safe_ssh_target() {
+  local name=$1
+  local value=$2
+
+  if [[ "$value" == -* || ! "$value" =~ ^([A-Za-z0-9._~-]+@)?[A-Za-z0-9._:-]+$ ]]; then
+    die "$name must be an SSH host or user@host target"
+  fi
+}
+
+require_safe_timezone() {
+  local name=$1
+  local value=$2
+
+  if [[ "$value" == -* || ! "$value" =~ ^[A-Za-z0-9_+./-]+$ ]]; then
+    die "$name must be an IANA-style timezone"
+  fi
+}

--- a/skills/cliproxy-newapi-stack/scripts/test_security_validation.sh
+++ b/skills/cliproxy-newapi-stack/scripts/test_security_validation.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=skills/cliproxy-newapi-stack/scripts/lib/validation.sh
+. "$SCRIPT_DIR/lib/validation.sh"
+
+failures=0
+
+assert_pass() {
+  local name=$1
+  shift
+  if ! ("$@"); then
+    printf 'FAIL expected pass: %s\n' "$name" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_fail() {
+  local name=$1
+  shift
+  if ("$@") >/dev/null 2>&1; then
+    printf 'FAIL expected rejection: %s\n' "$name" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_pass port_valid require_port PORT 8200
+assert_fail port_shell_meta require_port PORT '8200;id'
+assert_fail port_out_of_range require_port PORT 70000
+
+assert_pass path_valid require_absolute_safe_path DB /root/newapi/data/one-api.db
+assert_fail path_quote require_absolute_safe_path DB "/root/newapi/data/one-api.db';id'"
+assert_fail path_space require_absolute_safe_path DB '/root/newapi/data/one api.db'
+assert_fail path_traversal require_absolute_safe_path DB /root/newapi/../etc/passwd
+
+assert_pass ssh_target_valid require_safe_ssh_target SSH_TARGET root@1.2.3.4
+assert_fail ssh_target_option require_safe_ssh_target SSH_TARGET '-oProxyCommand=id'
+assert_fail ssh_target_shell_meta require_safe_ssh_target SSH_TARGET 'root@host;id'
+
+assert_pass docker_image_valid require_safe_docker_image IMAGE calciumion/new-api:latest
+assert_fail docker_image_option require_safe_docker_image IMAGE '-bad'
+assert_fail docker_image_shell_meta require_safe_docker_image IMAGE 'calciumion/new-api:latest;id'
+
+assert_pass container_valid require_safe_container_name CONTAINER new-api
+assert_fail container_shell_meta require_safe_container_name CONTAINER 'new-api;id'
+
+assert_pass model_valid require_safe_model_name MODEL gpt-5.4
+assert_fail model_json_breakout require_safe_model_name MODEL 'gpt";id'
+
+if ((failures > 0)); then
+  exit 1
+fi
+
+echo "security validation tests passed"

--- a/skills/cliproxy-newapi-stack/scripts/topup.sh
+++ b/skills/cliproxy-newapi-stack/scripts/topup.sh
@@ -7,6 +7,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=skills/cliproxy-newapi-stack/scripts/lib/validation.sh
+. "$SCRIPT_DIR/lib/validation.sh"
+
 : "${SSH_TARGET:?SSH_TARGET required}"
 : "${SSH_KEY:=$HOME/.ssh/id_ed25519}"
 : "${DB:=/root/newapi/data/one-api.db}"
@@ -15,10 +19,21 @@ set -euo pipefail
 USER_ID="${1:?user_id required}"
 QUOTA="${2:?quota integer required}"
 
-ssh -i "$SSH_KEY" "$SSH_TARGET" "
-  set -e
-  sqlite3 '$DB' \"UPDATE users SET quota=$QUOTA WHERE id=$USER_ID;\"
-  sqlite3 -header -column '$DB' \"SELECT id, username, quota, used_quota FROM users WHERE id=$USER_ID;\"
-  docker restart '$CONTAINER' >/dev/null
-  echo restarted '$CONTAINER'
-"
+require_safe_ssh_target SSH_TARGET "$SSH_TARGET"
+require_positive_uint USER_ID "$USER_ID"
+require_uint QUOTA "$QUOTA"
+require_absolute_safe_path DB "$DB"
+require_safe_container_name CONTAINER "$CONTAINER"
+
+ssh -i "$SSH_KEY" -- "$SSH_TARGET" bash -s -- "$USER_ID" "$QUOTA" "$DB" "$CONTAINER" <<'REMOTE'
+  set -euo pipefail
+  user_id=$1
+  quota=$2
+  db=$3
+  container=$4
+
+  sqlite3 "$db" "UPDATE users SET quota=$quota WHERE id=$user_id;"
+  sqlite3 -header -column "$db" "SELECT id, username, quota, used_quota FROM users WHERE id=$user_id;"
+  docker restart "$container" >/dev/null
+  echo "restarted ${container}"
+REMOTE

--- a/skills/cliproxy-newapi-stack/scripts/verify_stack.sh
+++ b/skills/cliproxy-newapi-stack/scripts/verify_stack.sh
@@ -14,6 +14,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=skills/cliproxy-newapi-stack/scripts/lib/validation.sh
+. "$SCRIPT_DIR/lib/validation.sh"
+
 : "${HOST:?HOST required}"
 : "${SSH_TARGET:?SSH_TARGET required}"
 : "${SSH_KEY:=$HOME/.ssh/id_ed25519}"
@@ -23,6 +27,13 @@ set -euo pipefail
 : "${NEWAPI_TOKEN:?NEWAPI_TOKEN required}"
 : "${MODEL:?MODEL required}"
 : "${DB:=/root/newapi/data/one-api.db}"
+
+require_safe_host HOST "$HOST"
+require_safe_ssh_target SSH_TARGET "$SSH_TARGET"
+require_port CLIPROXY_PORT "$CLIPROXY_PORT"
+require_port NEWAPI_PORT "$NEWAPI_PORT"
+require_safe_model_name MODEL "$MODEL"
+require_absolute_safe_path DB "$DB"
 
 payload='{"model":"'"$MODEL"'","messages":[{"role":"user","content":"reply OK"}],"stream":false,"max_tokens":4}'
 
@@ -43,8 +54,15 @@ echo "  HTTP $http_b"
 [ "$http_b" = "200" ] || { echo "FAIL via NewAPI"; cat /tmp/_newapi.json; exit 1; }
 
 echo "[3/3] NewAPI billing log (latest 3)"
-ssh -i "$SSH_KEY" "$SSH_TARGET" "sqlite3 -header -column '$DB' \
-  \"SELECT id, model_name, prompt_tokens, completion_tokens, quota, request_id \
-   FROM logs ORDER BY id DESC LIMIT 3;\""
+ssh -i "$SSH_KEY" -- "$SSH_TARGET" bash -s -- "$DB" <<'REMOTE'
+  set -euo pipefail
+  db=$1
+  sqlite3 -header -column "$db" <<'SQL'
+SELECT id, model_name, prompt_tokens, completion_tokens, quota, request_id
+  FROM logs
+ ORDER BY id DESC
+ LIMIT 3;
+SQL
+REMOTE
 
 echo OK both paths returned 200, latest billing log printed above


### PR DESCRIPTION
## Summary
- add shared allowlist/integer validators for CLIProxy/NewAPI maintenance scripts
- pass validated values into remote heredoc scripts instead of interpolating them into double-quoted SSH shell source
- validate SQLite user/quota inputs and DB/container/path/model parameters before remote execution
- add focused security validation tests for injection-shaped values

Closes #7

## Validation
- `bash -n skills/cliproxy-newapi-stack/scripts/deploy_newapi.sh skills/cliproxy-newapi-stack/scripts/topup.sh skills/cliproxy-newapi-stack/scripts/add_codex_account.sh skills/cliproxy-newapi-stack/scripts/verify_stack.sh skills/cliproxy-newapi-stack/scripts/lib/validation.sh skills/cliproxy-newapi-stack/scripts/test_security_validation.sh`
- `bash skills/cliproxy-newapi-stack/scripts/test_security_validation.sh`
- `shellcheck -x skills/cliproxy-newapi-stack/scripts/deploy_newapi.sh skills/cliproxy-newapi-stack/scripts/topup.sh skills/cliproxy-newapi-stack/scripts/add_codex_account.sh skills/cliproxy-newapi-stack/scripts/verify_stack.sh skills/cliproxy-newapi-stack/scripts/lib/validation.sh skills/cliproxy-newapi-stack/scripts/test_security_validation.sh`
- `python3 scripts/validate_skills.py`
- Representative malicious-input checks rejected `PORT='8200;id'`, `USER_ID='1;id'`, `SSH_TARGET='root@host;id'`, and `MODEL='gpt";id'` before any remote operation.
