### PR TITLE
docs: 修正 extended.md 中多个参考文档的超链接路径错误 

### DIFF
--- a/skills/harmonyos-app/reference/extended.md
+++ b/skills/harmonyos-app/reference/extended.md
@@ -589,8 +589,8 @@ export default function ProductPageUITest() {
 
 ## See Also
 
-- [reference/arkts.md](reference/arkts.md) — ArkTS language guide and restrictions
-- [reference/arkui.md](reference/arkui.md) — ArkUI components and styling
-- [reference/stage-model.md](reference/stage-model.md) — Stage model architecture
-- [reference/distributed.md](reference/distributed.md) — Distributed capabilities guide
-- [templates/project-structure.md](templates/project-structure.md) — Project template
+- [arkts.md](arkts.md) — ArkTS language guide and restrictions
+- [arkui.md](arkui.md) — ArkUI components and styling
+- [stage-model.md](stage-model.md) — Stage model architecture
+- [distributed.md](distributed.md) — Distributed capabilities guide
+- [project-template.md](../templates/project-template.md) — Project template


### PR DESCRIPTION
在 `skills/harmonyos-app/reference/extended.md` 文件中，“参考与延伸阅读 (See Also)”章节的多个链接使用了错误的相对路径，导致无法正确跳转到目标文档。


### 错误链接与正确链接对照

| 当前错误链接 | **✅ 正确链接** |
| :--- | :--- |
| `[reference/arkts.md](reference/arkts.md)` | `[arkts.md](arkts.md)` |
| `[reference/arkui.md](reference/arkui.md)` | `[arkui.md](arkui.md)` |
| `[reference/stage-model.md](reference/stage-model.md)` | `[stage-model.md](stage-model.md)` |
| `[reference/distributed.md](reference/distributed.md)` | `[distributed.md](distributed.md)` |
| `[templates/project-structure.md](templates/project-structure.md)` | `[project-template.md](../templates/project-template.md)` |

### 说明

- `extended.md` 与 `arkts.md` 等文件位于同一目录 `reference/` 下，因此链接应直接写文件名，无需额外的 `reference/` 前缀。
- 模板文件实际位于 `templates/` 目录（与 `reference/` 平级），且文件名为 `project-template.md`（而非 `project-structure.md`），需要使用 `../templates/project-template.md` 路径回退一级。


感谢维护！
感谢你的skill！