### PR TITLE
Add skill quality audit playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ Thumbs.db
 # Logs
 *.log
 
+# Python
+__pycache__/
+*.pyc
+
 # Local testing
 .local/
 tmp/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thanks for your interest in contributing!
 git clone https://github.com/majiayu000/spellbook.git
 cd spellbook
 python3 scripts/validate_skills.py --check
+python3 scripts/audit_skill_quality.py
 bash -n install.sh
 ```
 
@@ -16,24 +17,29 @@ bash -n install.sh
 - Follow existing code style
 - Add tests for new features
 - Run `python3 scripts/validate_skills.py --check` before opening a PR
+- Run `python3 scripts/audit_skill_quality.py <skill-name>` when adding or materially updating a skill
 - Commit messages: `<type>: <description>` (feat/fix/refactor/docs/test/chore)
 
 ## Adding or Updating a Skill
 
 1. Add the new skill directory or `*.SKILL.md` file under `skills/`.
-2. Map the skill to a category in `CATEGORY_BY_NAME` inside `scripts/validate_skills.py`.
-3. Regenerate registry artifacts:
+2. Pick one primary skill type and follow [Skill Quality Playbook](./docs/skill-quality-playbook.md).
+3. Write the `description` as a model-facing trigger: include "Use when" style intent, user phrasing, symptoms, and near-boundary context when relevant.
+4. For mature workflow skills, add gotchas and concrete verification signals. If the skill has `references/`, `scripts/`, `assets/`, `templates/`, or `evals/`, point to them from `SKILL.md`.
+5. Map the skill to a category in `CATEGORY_BY_NAME` inside `scripts/validate_skills.py`.
+6. Regenerate registry artifacts:
    ```bash
    python3 scripts/validate_skills.py --write
    ```
    This updates `registry/skills.json`, `registry/tags.json`, and `docs/skill-registry.md`.
-4. If the keyword heuristic mis-tags or under-tags the skill, add a curated entry to
+7. If the keyword heuristic mis-tags or under-tags the skill, add a curated entry to
    `registry/tag_overrides.yml` (overrides extend, never replace, the auto-detected tags).
-5. Update the skill counts in `README.md`, `README_CN.md`, and `install.sh` if a new
+8. Update the skill counts in `README.md`, `README_CN.md`, and `install.sh` if a new
    skill was added.
-6. Verify search behaves as expected:
+9. Verify search and quality signals behave as expected:
    ```bash
    python3 scripts/validate_skills.py search <your-skill-name>
+   python3 scripts/audit_skill_quality.py <your-skill-name>
    ```
 
 ## Pull Requests

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Release history lives in [Changelog](./CHANGELOG.md).
 
 > The generated full skill inventory lives in [Skill Registry](./docs/skill-registry.md).
 > Skill layout rules live in [Skill Format Policy](./docs/skill-format-policy.md).
+> Skill authoring quality rules live in [Skill Quality Playbook](./docs/skill-quality-playbook.md).
 
 ### Search the Registry
 
@@ -124,6 +125,13 @@ python3 scripts/validate_skills.py search --tag react --json
 ```
 
 The tag index lives in [`registry/tags.json`](./registry/tags.json) for tooling and dashboards. Curated overrides for skills the keyword heuristic cannot infer live in [`registry/tag_overrides.yml`](./registry/tag_overrides.yml).
+
+Audit non-blocking skill quality signals:
+
+```bash
+python3 scripts/audit_skill_quality.py
+python3 scripts/audit_skill_quality.py skill-creator
+```
 
 ### Development Architecture
 
@@ -273,6 +281,7 @@ Every skill in Spellbook follows these principles:
 | [Runtime Targets](./docs/runtime-targets.md) | Claude Code and Codex installation targets |
 | [Showcase](./docs/showcase.md) | Copy-paste workflow demos |
 | [Skill Format Policy](./docs/skill-format-policy.md) | Directory vs file skill layout rules |
+| [Skill Quality Playbook](./docs/skill-quality-playbook.md) | Trigger descriptions, gotchas, progressive disclosure, and verification |
 | [Skill Testing Guide](./docs/skill-testing-guide.md) | How to validate skills work |
 | [Creating Plugins](./docs/creating-plugins.md) | Build your own skills |
 | [Product Lifecycle (EN)](./docs/product-lifecycle-skills-en.md) | Full lifecycle coverage |

--- a/README_CN.md
+++ b/README_CN.md
@@ -106,6 +106,7 @@ Claude Code 仍是一等支持目标，也是用户搜索和认知入口。项�
 
 > 完整的自动生成清单位于 [Skill Registry](./docs/skill-registry.md)。
 > 技能目录/单文件格式规则见 [Skill Format Policy](./docs/skill-format-policy.md)。
+> Skill 编写质量规则见 [Skill Quality Playbook](./docs/skill-quality-playbook.md)。
 
 ### 检索技能
 
@@ -124,6 +125,13 @@ python3 scripts/validate_skills.py search --tag react --json
 ```
 
 标签索引位于 [`registry/tags.json`](./registry/tags.json)，可供面板/工具直接消费。无法被关键词启发式识别的标签可在 [`registry/tag_overrides.yml`](./registry/tag_overrides.yml) 中手动维护。
+
+审计非阻断的 skill 质量信号：
+
+```bash
+python3 scripts/audit_skill_quality.py
+python3 scripts/audit_skill_quality.py skill-creator
+```
 
 ### 开发架构
 
@@ -271,6 +279,7 @@ Spellbook 中的每个技能都遵循以下原则：
 | [Runtime 目标](./docs/runtime-targets.md) | Claude Code 与 Codex 安装目标 |
 | [Showcase](./docs/showcase.md) | 可直接复制的工作流演示 |
 | [技能格式策略](./docs/skill-format-policy.md) | 目录型与单文件 skill 的格式规则 |
+| [Skill Quality Playbook](./docs/skill-quality-playbook.md) | 触发描述、gotchas、渐进式披露与验证标准 |
 | [技能测试指南](./docs/skill-testing-guide.md) | 如何验证技能是否生效 |
 | [创建插件](./docs/creating-plugins.md) | 构建你自己的技能 |
 | [产品生命周期（英文）](./docs/product-lifecycle-skills-en.md) | 完整生命周期覆盖 |

--- a/docs/skill-quality-playbook.md
+++ b/docs/skill-quality-playbook.md
@@ -1,0 +1,81 @@
+# Skill Quality Playbook
+
+This playbook captures practical quality rules for Claude Arsenal skills. It is
+intended to complement [Skill Format Policy](./skill-format-policy.md): format
+policy says where files live, while this playbook says what makes a skill useful
+after the model discovers it.
+
+Source context: Anthropic's June 2026 post, "Lessons from building Claude Code:
+How we use skills", describes skills as folders of instructions, scripts, and
+resources, not just markdown files. It also highlights trigger descriptions,
+gotchas, progressive disclosure, verification scripts, setup state, persistent
+memory, hooks, distribution, composition, and usage measurement.
+
+## Skill Types
+
+Pick one primary type before writing or expanding a skill. Skills that straddle
+several types tend to confuse the model.
+
+| Type | Best use |
+|---|---|
+| Library and API reference | Correct use of a library, CLI, SDK, internal platform, or common footguns. |
+| Product verification | Browser, CLI, tmux, API, or state checks that prove the product works. |
+| Data fetching and analysis | Canonical queries, dashboards, metric names, and analysis helpers. |
+| Business process automation | Repeatable team workflow with required fields, previous-state logs, or handoffs. |
+| Code scaffolding and templates | Boilerplate where natural-language requirements still matter. |
+| Code quality and review | Deterministic style, review, testing, or policy checks. |
+| CI/CD and deployment | Build, smoke test, deploy, monitor, rollback, or PR babysitting. |
+| Runbooks | Symptom-driven investigation across tools that returns a structured report. |
+| Infrastructure operations | Guarded maintenance workflows, especially destructive or costly operations. |
+
+## Quality Bar
+
+Every new or materially changed skill should satisfy these checks:
+
+- **Trigger description**: `description` is written for the model, not humans. It
+  says when to use the skill, includes user phrasing or symptoms, and names near
+  boundaries when mis-triggering is likely.
+- **Non-obvious value**: `SKILL.md` should not restate what the model can infer
+  by reading the repo or general documentation. Put scarce knowledge first.
+- **Gotchas**: Mature skills include real failure modes, naming mismatches,
+  false-success signals, risky defaults, or common recovery paths.
+- **Progressive disclosure**: Keep `SKILL.md` as the router. Move detailed API
+  tables, long examples, templates, scripts, evals, and assets into support
+  directories and reference them from `SKILL.md`.
+- **Verification**: Workflow skills should include checks that prove completion:
+  scripts, assertions, smoke tests, browser checks, health checks, or explicit
+  done-when signals.
+- **Setup state**: Skills that need user or environment context should define a
+  config file or setup flow instead of asking repeatedly.
+- **Memory**: Repeated business workflows may store append-only logs, JSON, or a
+  small database in the plugin data directory when history changes the next run.
+- **Hooks**: Use on-demand hooks only for cases where temporary guardrails are
+  valuable, such as production operations or frozen edit scopes.
+
+## Review Workflow
+
+Use the lightweight audit before opening a PR:
+
+```bash
+python3 scripts/audit_skill_quality.py
+```
+
+Scope it to a changed skill when working incrementally:
+
+```bash
+python3 scripts/audit_skill_quality.py skill-creator
+```
+
+Use warnings as review prompts, not as automatic blockers. A warning can be
+acceptable when the skill is intentionally tiny, subjective, or still in manual
+validation. For release gates, opt in explicitly:
+
+```bash
+python3 scripts/audit_skill_quality.py --fail-on-warn
+```
+
+The existing registry validation remains the required correctness gate:
+
+```bash
+python3 scripts/validate_skills.py --check
+```

--- a/scripts/audit_skill_quality.py
+++ b/scripts/audit_skill_quality.py
@@ -8,6 +8,7 @@ from collections import Counter
 from dataclasses import asdict, dataclass
 import json
 from pathlib import Path
+import re
 import sys
 
 from validate_skills import CATEGORY_BY_NAME, ROOT, SkillEntry, discover_skills, parse_frontmatter
@@ -82,6 +83,17 @@ VERIFICATION_CATEGORIES = {
     "UI/UX & Frontend",
 }
 
+LOCAL_SUPPORT_REF_RE = re.compile(
+    r"(?<![/\w.-])"
+    r"((?:skills/[A-Za-z0-9_.-]+/)?"
+    r"(?:agents|assets|evals|reference|references|scripts|templates)"
+    r"/[A-Za-z0-9_./-]+\.[A-Za-z0-9]+)"
+)
+
+IGNORED_MISSING_REFS = {
+    ("skill-creator", "evals/evals.json"),
+}
+
 
 @dataclass(frozen=True)
 class QualityFinding:
@@ -116,6 +128,23 @@ def support_dirs_for(entry: SkillEntry) -> list[str]:
         for child in skill_dir.iterdir()
         if child.is_dir() and child.name in SUPPORT_DIR_NAMES
     )
+
+
+def referenced_local_support_files(entry: SkillEntry, body: str) -> list[tuple[str, Path]]:
+    refs: list[tuple[str, Path]] = []
+    seen: set[str] = set()
+    for match in LOCAL_SUPPORT_REF_RE.finditer(body):
+        ref = match.group(1).rstrip(".,:;)")
+        if (entry.install_name, ref) in IGNORED_MISSING_REFS or ref in seen:
+            continue
+        seen.add(ref)
+        if ref.startswith("skills/"):
+            refs.append((ref, ROOT / ref))
+        elif entry.format == "directory":
+            refs.append((ref, (ROOT / entry.path).parent / ref))
+        else:
+            refs.append((ref, ROOT / "skills" / ref))
+    return refs
 
 
 def audit_entry(entry: SkillEntry) -> list[QualityFinding]:
@@ -206,6 +235,18 @@ def audit_entry(entry: SkillEntry) -> list[QualityFinding]:
                     entry.path,
                     "support-reference",
                     f"support directory '{support_dir}/' exists but is not referenced from SKILL.md",
+                )
+            )
+
+    for ref, target in referenced_local_support_files(entry, body):
+        if not target.exists():
+            findings.append(
+                QualityFinding(
+                    "WARN",
+                    entry.install_name,
+                    entry.path,
+                    "missing-support-file",
+                    f"referenced support file '{ref}' does not exist at {target.relative_to(ROOT)}",
                 )
             )
 

--- a/scripts/audit_skill_quality.py
+++ b/scripts/audit_skill_quality.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Report non-blocking quality signals for Claude Arsenal skills."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+import sys
+
+from validate_skills import CATEGORY_BY_NAME, ROOT, SkillEntry, discover_skills, parse_frontmatter
+
+
+SUPPORT_DIR_NAMES = {
+    "agents",
+    "assets",
+    "evals",
+    "reference",
+    "references",
+    "scripts",
+    "templates",
+}
+
+TRIGGER_CUES = (
+    "use when",
+    "use this skill",
+    "whenever",
+    "when the user",
+    "trigger",
+    "当用户",
+    "用于",
+    "适用",
+)
+
+GOTCHA_CUES = (
+    "gotcha",
+    "gotchas",
+    "pitfall",
+    "pitfalls",
+    "footgun",
+    "failure mode",
+    "common failure",
+    "troubleshoot",
+    "troubleshooting",
+    "edge case",
+    "caveat",
+    "注意",
+    "踩坑",
+    "常见问题",
+    "风险",
+    "失败",
+    "排查",
+    "故障",
+)
+
+VERIFICATION_CUES = (
+    "assert",
+    "check",
+    "health check",
+    "playwright",
+    "smoke",
+    "test",
+    "tests",
+    "validate",
+    "validation",
+    "verification",
+    "verify",
+    "断言",
+    "检查",
+    "验证",
+    "测试",
+    "自检",
+)
+
+VERIFICATION_CATEGORIES = {
+    "API & Backend",
+    "Delivery Workflow",
+    "Development Architecture",
+    "Operations & Deploy",
+    "UI/UX & Frontend",
+}
+
+
+@dataclass(frozen=True)
+class QualityFinding:
+    severity: str
+    skill: str
+    path: str
+    check: str
+    message: str
+
+
+def skill_markdown_body(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return text
+    return text[end + len("\n---") :]
+
+
+def contains_any(text: str, cues: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(cue.lower() in lowered for cue in cues)
+
+
+def support_dirs_for(entry: SkillEntry) -> list[str]:
+    if entry.format != "directory":
+        return []
+    skill_dir = (ROOT / entry.path).parent
+    return sorted(
+        child.name
+        for child in skill_dir.iterdir()
+        if child.is_dir() and child.name in SUPPORT_DIR_NAMES
+    )
+
+
+def audit_entry(entry: SkillEntry) -> list[QualityFinding]:
+    path = ROOT / entry.path
+    frontmatter, _ = parse_frontmatter(path)
+    description = frontmatter.get("description", "")
+    description_text = description if isinstance(description, str) else ""
+    body = skill_markdown_body(path)
+    searchable_text = f"{description_text}\n{body}"
+    line_count = len(path.read_text(encoding="utf-8").splitlines())
+    category = CATEGORY_BY_NAME.get(entry.install_name, "Uncategorized")
+    findings: list[QualityFinding] = []
+
+    if description_text and not contains_any(description_text, TRIGGER_CUES):
+        findings.append(
+            QualityFinding(
+                "WARN",
+                entry.install_name,
+                entry.path,
+                "trigger-description",
+                "description reads like a summary; add model-facing trigger cues such as 'Use when' or user phrasing",
+            )
+        )
+
+    if 0 < len(description_text.strip()) < 80:
+        findings.append(
+            QualityFinding(
+                "INFO",
+                entry.install_name,
+                entry.path,
+                "short-description",
+                "description is short; verify it includes enough intent, symptoms, and near-boundary context",
+            )
+        )
+
+    if not contains_any(body, GOTCHA_CUES):
+        findings.append(
+            QualityFinding(
+                "INFO",
+                entry.install_name,
+                entry.path,
+                "gotchas",
+                "SKILL.md has no obvious gotchas/failure-mode section; add one when real failure patterns are known",
+            )
+        )
+
+    if category in VERIFICATION_CATEGORIES and not contains_any(searchable_text, VERIFICATION_CUES):
+        findings.append(
+            QualityFinding(
+                "WARN",
+                entry.install_name,
+                entry.path,
+                "verification",
+                "workflow category has no obvious verification signal; add checks, scripts, assertions, or explicit done-when proof",
+            )
+        )
+
+    if entry.format == "file" and line_count > 160:
+        findings.append(
+            QualityFinding(
+                "WARN",
+                entry.install_name,
+                entry.path,
+                "file-size",
+                "large file skill should migrate to directory layout before adding references, scripts, assets, or evals",
+            )
+        )
+
+    support_dirs = support_dirs_for(entry)
+    if entry.format == "directory" and line_count > 300 and not support_dirs:
+        findings.append(
+            QualityFinding(
+                "WARN",
+                entry.install_name,
+                entry.path,
+                "progressive-disclosure",
+                "long SKILL.md has no support directory; split detailed material into references, scripts, templates, assets, or evals",
+            )
+        )
+
+    body_lower = body.lower()
+    for support_dir in support_dirs:
+        if support_dir.lower() not in body_lower:
+            findings.append(
+                QualityFinding(
+                    "WARN",
+                    entry.install_name,
+                    entry.path,
+                    "support-reference",
+                    f"support directory '{support_dir}/' exists but is not referenced from SKILL.md",
+                )
+            )
+
+    return findings
+
+
+def audit_skills(entries: list[SkillEntry], skill_names: set[str] | None = None) -> list[QualityFinding]:
+    findings: list[QualityFinding] = []
+    for entry in entries:
+        if skill_names and entry.install_name not in skill_names:
+            continue
+        findings.extend(audit_entry(entry))
+    return findings
+
+
+def render_text(findings: list[QualityFinding], total_skills: int) -> str:
+    counts = Counter(finding.severity for finding in findings)
+    lines = [
+        f"Audited {total_skills} skill(s): {counts.get('WARN', 0)} warnings, {counts.get('INFO', 0)} info",
+    ]
+    if not findings:
+        return "\n".join(lines) + "\n"
+
+    lines.append("")
+    check_counts = Counter(finding.check for finding in findings)
+    lines.append("Finding counts:")
+    for check, count in sorted(check_counts.items()):
+        lines.append(f"- {check}: {count}")
+
+    lines.append("")
+    for finding in findings:
+        lines.append(
+            f"{finding.severity}: {finding.skill} [{finding.check}] {finding.message} ({finding.path})"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("skills", nargs="*", help="Optional install names to audit")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument("--fail-on-warn", action="store_true", help="Exit non-zero when WARN findings exist")
+    args = parser.parse_args()
+
+    entries = discover_skills()
+    known_names = {entry.install_name for entry in entries}
+    requested_names = set(args.skills)
+    unknown_names = requested_names - known_names
+    if unknown_names:
+        print(f"Unknown skill(s): {', '.join(sorted(unknown_names))}", file=sys.stderr)
+        return 2
+
+    findings = audit_skills(entries, requested_names or None)
+    audited_count = len(requested_names) if requested_names else len(entries)
+
+    if args.json:
+        payload = {
+            "audited_skills": audited_count,
+            "summary": dict(Counter(finding.severity for finding in findings)),
+            "findings": [asdict(finding) for finding in findings],
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(render_text(findings, audited_count), end="")
+
+    has_warnings = any(finding.severity == "WARN" for finding in findings)
+    return 1 if args.fail_on_warn and has_warnings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -59,6 +59,8 @@ Proactively ask questions about edge cases, input/output formats, example files,
 
 Check available MCPs - if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
 
+For new or materially changed skills, read `references/quality-playbook.md` before drafting. Use it to choose one primary skill type, decide whether the skill needs gotchas, scripts, setup state, hooks, or verification, and avoid bloating `SKILL.md` with details that belong in support files.
+
 ### Write the SKILL.md
 
 Based on the user interview, fill in these components:
@@ -460,6 +462,7 @@ The agents/ directory contains instructions for specialized subagents. Read them
 
 The references/ directory has additional documentation:
 - `references/schemas.md` — JSON structures for evals.json, grading.json, etc.
+- `references/quality-playbook.md` — skill type selection, trigger description rules, gotchas, progressive disclosure, and verification checks
 
 ---
 

--- a/skills/skill-creator/references/quality-playbook.md
+++ b/skills/skill-creator/references/quality-playbook.md
@@ -1,0 +1,56 @@
+# Skill Quality Playbook
+
+Use this reference when creating or materially improving a skill. Keep the main
+`SKILL.md` short; put large reference tables, scripts, templates, and examples
+behind progressive disclosure.
+
+## Pick One Primary Type
+
+Choose the skill's main job before writing:
+
+- Library/API reference: how to use a library, CLI, SDK, or internal platform.
+- Product verification: scripts or tool flows that prove product behavior.
+- Data fetching/analysis: canonical queries, dashboards, metric names, helpers.
+- Business process automation: repeatable team workflow with required state.
+- Code scaffolding/templates: boilerplate plus natural-language requirements.
+- Code quality/review: deterministic style, review, testing, or policy checks.
+- CI/CD/deployment: build, smoke test, deploy, monitor, rollback, PR babysitting.
+- Runbook: symptom-driven investigation that returns a structured report.
+- Infrastructure operations: guarded maintenance, especially risky actions.
+
+If a draft has two or three primary types, split it or make `SKILL.md` a router
+that points to narrower references.
+
+## High-Signal Sections
+
+- **Description**: Write for triggering, not summary. Include when to use the
+  skill, user phrasing, symptoms, and near-boundary cases.
+- **Gotchas**: Add observed failure modes, naming mismatches, false-success
+  signals, risky defaults, and recovery checks.
+- **Verification**: For objective workflows, include scripts, assertions, smoke
+  tests, browser checks, health checks, or explicit done-when proof.
+- **Support files**: Use `references/`, `scripts/`, `assets/`, `templates/`, and
+  `evals/` when detail would otherwise bloat `SKILL.md`.
+- **Setup**: If the skill needs user or environment context, describe a config
+  file or setup flow instead of asking repeatedly.
+- **Memory**: Repeated workflows can keep append-only logs, JSON, or SQLite state
+  when previous runs change the next run.
+- **Hooks**: Use on-demand hooks only for temporary guardrails that would be too
+  annoying to run globally.
+
+## Authoring Checks
+
+Before calling a skill good, ask:
+
+1. Would the model know to trigger this from the `description` alone?
+2. Does the skill teach something non-obvious or repo/org-specific?
+3. Are the common failure modes captured as gotchas?
+4. Does `SKILL.md` point clearly to every support directory it expects to use?
+5. Is there a concrete verification path for objective work?
+6. Are risky or destructive actions guarded by confirmation or checks?
+
+Run the repository-level audit when available:
+
+```bash
+python3 scripts/audit_skill_quality.py <skill-name>
+```


### PR DESCRIPTION
## Summary
- add a non-blocking skill quality audit script for trigger descriptions, gotchas, support-file references, progressive disclosure, verification signals, and file-size warnings
- document the skill quality playbook inspired by Claude Code skills lessons
- wire the playbook into skill-creator and contributor docs
- ignore Python bytecode generated by local validation

## Validation
- python3 scripts/validate_skills.py --check
- python3 scripts/audit_skill_quality.py skill-creator --fail-on-warn
- bash -n install.sh
- git diff --check

Refs #27
