### PR TITLE
Fix web-artifacts-builder scripts

### DIFF
--- a/skills/web-artifacts-builder/SKILL.md
+++ b/skills/web-artifacts-builder/SKILL.md
@@ -33,8 +33,7 @@ This creates a fully configured project with:
 - ✅ React + TypeScript (via Vite)
 - ✅ Tailwind CSS 3.4.1 with shadcn/ui theming system
 - ✅ Path aliases (`@/`) configured
-- ✅ 40+ shadcn/ui components pre-installed
-- ✅ All Radix UI dependencies included
+- ✅ Starter structure for shadcn/ui-style components
 - ✅ Parcel configured for bundling (via .parcelrc)
 - ✅ Node 18+ compatibility (auto-detects and pins Vite version)
 

--- a/skills/web-artifacts-builder/scripts/bundle-artifact.sh
+++ b/skills/web-artifacts-builder/scripts/bundle-artifact.sh
@@ -24,17 +24,99 @@ const distDir = "dist-artifact";
 const htmlPath = path.join(distDir, "index.html");
 let html = fs.readFileSync(htmlPath, "utf8");
 
+const mimeTypes = {
+  ".avif": "image/avif",
+  ".gif": "image/gif",
+  ".ico": "image/x-icon",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".mp3": "audio/mpeg",
+  ".mp4": "video/mp4",
+  ".otf": "font/otf",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".ttf": "font/ttf",
+  ".webm": "video/webm",
+  ".webp": "image/webp",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+};
+
+const localAssetPattern = /\.(?:avif|gif|ico|jpe?g|mp3|mp4|otf|png|svg|ttf|webm|webp|woff2?)(?:[?#][^"')\s]+)?$/i;
+
+function isExternalReference(ref) {
+  return /^(?:data:|https?:|mailto:|tel:|#|javascript:)/i.test(ref);
+}
+
+function resolveAsset(ref, baseDir) {
+  if (!ref || isExternalReference(ref) || !localAssetPattern.test(ref)) {
+    return null;
+  }
+  const cleanRef = ref.split(/[?#]/, 1)[0];
+  const candidates = [
+    path.join(baseDir, cleanRef),
+    path.join(distDir, cleanRef.replace(/^\//, "")),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile()) ?? null;
+}
+
+function toDataUri(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  const mime = mimeTypes[ext] ?? "application/octet-stream";
+  const data = fs.readFileSync(filePath).toString("base64");
+  return `data:${mime};base64,${data}`;
+}
+
+function inlineAssetReferences(text, baseDir) {
+  let output = text.replace(/url\((["']?)([^"')]+)\1\)/g, (match, quote, ref) => {
+    const filePath = resolveAsset(ref.trim(), baseDir);
+    if (!filePath) {
+      return match;
+    }
+    return `url(${quote}${toDataUri(filePath)}${quote})`;
+  });
+  output = output.replace(
+    /(["'])(\/?[^"']+\.(?:avif|gif|ico|jpe?g|mp3|mp4|otf|png|svg|ttf|webm|webp|woff2?)(?:[?#][^"']*)?)\1/gi,
+    (match, quote, ref) => {
+      const filePath = resolveAsset(ref, baseDir);
+      if (!filePath) {
+        return match;
+      }
+      return `${quote}${toDataUri(filePath)}${quote}`;
+    }
+  );
+  return output;
+}
+
+function inlineHtmlAssetAttributes(text) {
+  return text.replace(
+    /\b(src|href)=(")([^"]+\.(?:avif|gif|ico|jpe?g|mp3|mp4|otf|png|svg|ttf|webm|webp|woff2?)(?:[?#][^"]*)?)(")/gi,
+    (match, attribute, openQuote, ref, closeQuote) => {
+      const filePath = resolveAsset(ref, distDir);
+      if (!filePath) {
+        return match;
+      }
+      return `${attribute}=${openQuote}${toDataUri(filePath)}${closeQuote}`;
+    }
+  );
+}
+
 html = html.replace(/<script([^>]*)src="([^"]+)"([^>]*)><\/script>/g, (_match, before, src, after) => {
   const filePath = path.join(distDir, src.replace(/^\//, ""));
-  const code = fs.readFileSync(filePath, "utf8");
+  const code = inlineAssetReferences(fs.readFileSync(filePath, "utf8"), path.dirname(filePath)).replace(
+    /<\/script/gi,
+    "<\\/script"
+  );
   return `<script${before}${after}>${code}</script>`;
 });
 
 html = html.replace(/<link([^>]*?)rel="stylesheet"([^>]*?)href="([^"]+)"([^>]*)>/g, (_match, before, middle, href, after) => {
   const filePath = path.join(distDir, href.replace(/^\//, ""));
-  const css = fs.readFileSync(filePath, "utf8");
+  const css = inlineAssetReferences(fs.readFileSync(filePath, "utf8"), path.dirname(filePath));
   return `<style${before}${middle}${after}>${css}</style>`;
 });
+
+html = inlineHtmlAssetAttributes(html);
 
 fs.writeFileSync("bundle.html", html);
 NODE

--- a/skills/web-artifacts-builder/scripts/bundle-artifact.sh
+++ b/skills/web-artifacts-builder/scripts/bundle-artifact.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f "index.html" ]]; then
+  echo "error: run this script from the artifact project root containing index.html" >&2
+  exit 1
+fi
+
+if [[ ! -d "node_modules" ]]; then
+  echo "error: node_modules not found. Run npm install before bundling." >&2
+  exit 1
+fi
+
+dist_dir="dist-artifact"
+rm -rf "$dist_dir"
+
+npx parcel build index.html --dist-dir "$dist_dir" --no-source-maps
+
+node <<'NODE'
+import fs from "node:fs";
+import path from "node:path";
+
+const distDir = "dist-artifact";
+const htmlPath = path.join(distDir, "index.html");
+let html = fs.readFileSync(htmlPath, "utf8");
+
+html = html.replace(/<script([^>]*)src="([^"]+)"([^>]*)><\/script>/g, (_match, before, src, after) => {
+  const filePath = path.join(distDir, src.replace(/^\//, ""));
+  const code = fs.readFileSync(filePath, "utf8");
+  return `<script${before}${after}>${code}</script>`;
+});
+
+html = html.replace(/<link([^>]*?)rel="stylesheet"([^>]*?)href="([^"]+)"([^>]*)>/g, (_match, before, middle, href, after) => {
+  const filePath = path.join(distDir, href.replace(/^\//, ""));
+  const css = fs.readFileSync(filePath, "utf8");
+  return `<style${before}${middle}${after}>${css}</style>`;
+});
+
+fs.writeFileSync("bundle.html", html);
+NODE
+
+echo "Created bundle.html"

--- a/skills/web-artifacts-builder/scripts/init-artifact.sh
+++ b/skills/web-artifacts-builder/scripts/init-artifact.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_name="${1:-}"
+if [[ -z "$project_name" ]]; then
+  echo "usage: bash scripts/init-artifact.sh <project-name>" >&2
+  exit 2
+fi
+
+if [[ -e "$project_name" ]]; then
+  echo "error: target already exists: $project_name" >&2
+  exit 1
+fi
+
+mkdir -p "$project_name/src/components/ui"
+cd "$project_name"
+
+cat > package.json <<'JSON'
+{
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0",
+    "build": "vite build",
+    "bundle": "bash ../scripts/bundle-artifact.sh"
+  },
+  "dependencies": {
+    "@vitejs/plugin-react": "^4.3.0",
+    "autoprefixer": "^10.4.19",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.468.0",
+    "postcss": "^8.4.38",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tailwind-merge": "^2.3.0",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "html-inline": "^1.2.0",
+    "parcel": "^2.12.0"
+  }
+}
+JSON
+
+cat > index.html <<'HTML'
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Claude Artifact</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+HTML
+
+cat > src/main.tsx <<'TSX'
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+TSX
+
+cat > src/App.tsx <<'TSX'
+export function App() {
+  return (
+    <main className="min-h-screen bg-zinc-950 text-zinc-50">
+      <section className="mx-auto flex min-h-screen max-w-5xl flex-col justify-center px-8">
+        <p className="mb-4 text-sm uppercase tracking-[0.2em] text-cyan-300">Claude Artifact</p>
+        <h1 className="max-w-3xl text-5xl font-semibold leading-tight">
+          Replace this starter with the user's actual interactive experience.
+        </h1>
+        <p className="mt-6 max-w-2xl text-lg text-zinc-300">
+          Use React state, focused components, and Tailwind utilities. Keep the final artifact
+          self-contained by running the bundle script from the project root.
+        </p>
+      </section>
+    </main>
+  );
+}
+TSX
+
+cat > src/index.css <<'CSS'
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+CSS
+
+cat > src/components/ui/README.md <<'MD'
+# UI Components
+
+Put small reusable shadcn/ui-style components here. Keep component APIs narrow
+and prefer plain Tailwind classes unless a reusable abstraction removes real
+duplication.
+MD
+
+cat > tsconfig.json <<'JSON'
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": []
+}
+JSON
+
+cat > vite.config.ts <<'TS'
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": "/src",
+    },
+  },
+});
+TS
+
+cat > tailwind.config.js <<'JS'
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+JS
+
+cat > postcss.config.js <<'JS'
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+JS
+
+cat > .parcelrc <<'JSON'
+{
+  "extends": "@parcel/config-default"
+}
+JSON
+
+echo "Created artifact project: $project_name"
+echo "Next: cd $project_name && npm install && npm run dev"

--- a/skills/web-artifacts-builder/scripts/init-artifact.sh
+++ b/skills/web-artifacts-builder/scripts/init-artifact.sh
@@ -6,6 +6,7 @@ if [[ -z "$project_name" ]]; then
   echo "usage: bash scripts/init-artifact.sh <project-name>" >&2
   exit 2
 fi
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ -e "$project_name" ]]; then
   echo "error: target already exists: $project_name" >&2
@@ -21,7 +22,7 @@ cat > package.json <<'JSON'
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "vite build",
-    "bundle": "bash ../scripts/bundle-artifact.sh"
+    "bundle": "bash scripts/bundle-artifact.sh"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^4.3.0",
@@ -181,6 +182,10 @@ cat > .parcelrc <<'JSON'
   "extends": "@parcel/config-default"
 }
 JSON
+
+mkdir -p scripts
+cp "$script_dir/bundle-artifact.sh" scripts/bundle-artifact.sh
+chmod +x scripts/bundle-artifact.sh
 
 echo "Created artifact project: $project_name"
 echo "Next: cd $project_name && npm install && npm run dev"


### PR DESCRIPTION
## Summary
- add the missing artifact initialization script referenced by web-artifacts-builder
- add the missing bundle script for producing `bundle.html`
- correct the skill text so it no longer claims Radix/shadcn components are preinstalled

## Validation
- `bash -n skills/web-artifacts-builder/scripts/init-artifact.sh`
- `bash -n skills/web-artifacts-builder/scripts/bundle-artifact.sh`
- `bash /Users/lifcc/Desktop/code/AI/tools/claude-arsenal/skills/web-artifacts-builder/scripts/init-artifact.sh demo-artifact` in a temp directory
- `python3 scripts/validate_skills.py --check`
- `git diff --check`

Closes #33
Refs #27