### PR TITLE
Fix playwright-automation missing server helper

### DIFF
--- a/skills/playwright-automation.SKILL.md
+++ b/skills/playwright-automation.SKILL.md
@@ -272,6 +272,8 @@ try {
 
 ```bash
 # Start multiple servers in the background, run the test, then clean up.
+set -euo pipefail
+
 npm run dev > /tmp/playwright-dev.log 2>&1 &
 DEV_PID=$!
 npm run api > /tmp/playwright-api.log 2>&1 &
@@ -281,6 +283,46 @@ cleanup() {
   kill "$DEV_PID" "$API_PID" 2>/dev/null || true
 }
 trap cleanup EXIT
+
+wait_for_port() {
+  local port="$1"
+  node - "$port" <<'NODE'
+const net = require("node:net");
+
+const port = Number(process.argv[2]);
+const deadline = Date.now() + 30000;
+
+function attempt() {
+  const socket = net.createConnection({ host: "127.0.0.1", port });
+  let settled = false;
+
+  const retry = () => {
+    if (settled) return;
+    settled = true;
+    socket.destroy();
+    if (Date.now() > deadline) {
+      console.error(`Timed out waiting for port ${port}`);
+      process.exit(1);
+    }
+    setTimeout(attempt, 250);
+  };
+
+  socket.setTimeout(1000);
+  socket.on("connect", () => {
+    settled = true;
+    socket.end();
+    process.exit(0);
+  });
+  socket.on("error", retry);
+  socket.on("timeout", retry);
+}
+
+attempt();
+NODE
+}
+
+wait_for_port 3000
+wait_for_port 5000
 
 node /tmp/playwright-test.js
 ```

--- a/skills/playwright-automation.SKILL.md
+++ b/skills/playwright-automation.SKILL.md
@@ -271,11 +271,18 @@ try {
 ## Multi-Server Setup
 
 ```bash
-# Start multiple servers, then run test
-python scripts/with_server.py \
-  --server "npm run dev" --port 3000 \
-  --server "npm run api" --port 5000 \
-  -- node /tmp/playwright-test.js
+# Start multiple servers in the background, run the test, then clean up.
+npm run dev > /tmp/playwright-dev.log 2>&1 &
+DEV_PID=$!
+npm run api > /tmp/playwright-api.log 2>&1 &
+API_PID=$!
+
+cleanup() {
+  kill "$DEV_PID" "$API_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+node /tmp/playwright-test.js
 ```
 
 ## Quick Reference


### PR DESCRIPTION
## Summary
- remove the reference to missing `scripts/with_server.py`
- replace it with an inline multi-server background process example that cleans up PIDs on exit

## Validation
- `rg -n "with_server\\.py|scripts/with_server" skills/playwright-automation.SKILL.md` returns no matches
- `python3 scripts/validate_skills.py --check`
- `git diff --check`

Closes #34
Refs #27