### PR TITLE
fix: codebase-audit P0 失效引用修复 + P1 质量门（统一输出契约 / Phase 1.5 复核 / 依赖审计 / 基线 diff）

### DIFF
--- a/skills/codebase-audit/SKILL.md
+++ b/skills/codebase-audit/SKILL.md
@@ -65,11 +65,11 @@ When both frontend and backend exist (e.g., React + FastAPI, Next.js + Go).
 
 | # | Agent | Type | Scope (merged dimensions) |
 |---|-------|------|---------------------------|
-| 1 | **Frontend-Backend Contract** | `code-reviewer` | Type consistency (field names, types, missing fields) + Rendering pipeline (layout/block/card routing completeness, dead slots, unrendered fields) + Serialization boundaries (models that silently drop fields). This agent reads BOTH sides and traces data across the API boundary. |
-| 2 | **Data Integrity & Flow** | `code-reviewer` | Data pipeline end-to-end: from input through every transformation layer to output. Covers: field resolver filters, serialization/deserialization, model_validate/model_dump, cache read/write symmetry, registry key-set alignment (sole owner — Agent 4 must not re-check). Also covers: declaration-execution gaps (registered but unwired handlers, enum without config), and Concurrency & Async Hygiene when an async runtime is detected. |
-| 3 | **Error Handling & Security** | `security-reviewer` | Exception patterns (bare except, debug-level errors, warning+fallback), security (hardcoded secrets, injection, unsafe deserialization), silent degradation (error paths that produce user-visible wrong output instead of failing), classification of Phase 0 dependency-audit output. |
-| 4 | **Architecture & Code Quality** | `architect` | Layer violations, circular dependencies, god objects (files >800 lines), code duplication (parallel systems, scattered mapping tables), extension cost analysis (how many files to add a new type), DI pattern consistency, test quality (coverage gaps, weakened assertions, skip markers, stale tests). |
-| 5 | **Config & Persistence** | `database-reviewer` | Config completeness (template/schema vs code expectations, conflicting defaults), cache key completeness (missing code version dimension), DB schema consistency, temp file cleanup, state persistence across restarts. |
+| 1 | **Frontend-Backend Contract** | `senior-code-reviewer` | Type consistency (field names, types, missing fields) + Rendering pipeline (layout/block/card routing completeness, dead slots, unrendered fields) + Serialization boundaries (models that silently drop fields). This agent reads BOTH sides and traces data across the API boundary. |
+| 2 | **Data Integrity & Flow** | `senior-code-reviewer` | Data pipeline end-to-end: from input through every transformation layer to output. Covers: field resolver filters, serialization/deserialization, model_validate/model_dump, cache read/write symmetry, registry key-set alignment (sole owner — Agent 4 must not re-check). Also covers: declaration-execution gaps (registered but unwired handlers, enum without config), and Concurrency & Async Hygiene when an async runtime is detected. |
+| 3 | **Error Handling & Security** | `security-auditor` | Exception patterns (bare except, debug-level errors, warning+fallback), security (hardcoded secrets, injection, unsafe deserialization), silent degradation (error paths that produce user-visible wrong output instead of failing), classification of Phase 0 dependency-audit output. |
+| 4 | **Architecture & Code Quality** | `code-archaeologist` | Layer violations, circular dependencies, god objects (files >800 lines), code duplication (parallel systems, scattered mapping tables), extension cost analysis (how many files to add a new type), DI pattern consistency, test quality (coverage gaps, weakened assertions, skip markers, stale tests). |
+| 5 | **Config & Persistence** | `code-archaeologist` | Config completeness (template/schema vs code expectations, conflicting defaults), cache key completeness (missing code version dimension), DB schema consistency, temp file cleanup, state persistence across restarts. |
 
 ---
 
@@ -79,10 +79,10 @@ When only backend exists (Python API, Rust service, Go microservice, etc.)
 
 | # | Agent | Type | Scope |
 |---|-------|------|-------|
-| 1 | **API Contract & Data Integrity** | `code-reviewer` | API schema vs internal models, serialization boundaries, data pipeline tracing, field dropping, registry key-set alignment, declaration-execution gaps, concurrency hygiene when async runtime detected. |
-| 2 | **Error Handling & Security** | `security-reviewer` | Same as full-stack Agent 3. |
-| 3 | **Architecture & Code Quality** | `architect` | Same as full-stack Agent 4. |
-| 4 | **Config & Persistence** | `database-reviewer` | Same as full-stack Agent 5. |
+| 1 | **API Contract & Data Integrity** | `senior-code-reviewer` | API schema vs internal models, serialization boundaries, data pipeline tracing, field dropping, registry key-set alignment, declaration-execution gaps, concurrency hygiene when async runtime detected. |
+| 2 | **Error Handling & Security** | `security-auditor` | Same as full-stack Agent 3. |
+| 3 | **Architecture & Code Quality** | `code-archaeologist` | Same as full-stack Agent 4. |
+| 4 | **Config & Persistence** | `code-archaeologist` | Same as full-stack Agent 5. |
 
 ---
 
@@ -92,9 +92,9 @@ When only frontend exists (React SPA, Vue app, etc.)
 
 | # | Agent | Type | Scope |
 |---|-------|------|-------|
-| 1 | **Component Architecture & Rendering** | `code-reviewer` | Type routing completeness, component registration gaps, dead props/slots, state management consistency, API consumption patterns, minimal accessibility checks (alt/label/keyboard reachability). |
-| 2 | **Error Handling & Code Quality** | `code-reviewer` | Unhandled promise rejections, error boundaries, catch-and-ignore patterns, god components, code duplication, test quality, dependency-audit classification. |
-| 3 | **Config & Build** | `general-purpose` | Build config consistency, env variable management, bundle analysis, dead dependencies. |
+| 1 | **Component Architecture & Rendering** | `senior-code-reviewer` | Type routing completeness, component registration gaps, dead props/slots, state management consistency, API consumption patterns, minimal accessibility checks (alt/label/keyboard reachability). |
+| 2 | **Error Handling & Code Quality** | `senior-code-reviewer` | Unhandled promise rejections, error boundaries, catch-and-ignore patterns, god components, code duplication, test quality, dependency-audit classification. |
+| 3 | **Config & Build** | `code-archaeologist` | Build config consistency, env variable management, bundle analysis, dead dependencies. |
 
 ---
 

--- a/skills/codebase-audit/SKILL.md
+++ b/skills/codebase-audit/SKILL.md
@@ -5,13 +5,14 @@ description: "全面代码库审计 — 自适应并行深度分析（前后端�
 
 # Codebase Audit — Adaptive Deep Analysis
 
-A comprehensive codebase audit that adapts its agent configuration to the project's tech stack. Each agent uses opus for maximum thoroughness. Results are compiled into a unified report sorted by severity with a phased repair roadmap.
+A comprehensive codebase audit that adapts its agent configuration to the project's tech stack. Each agent uses the highest-tier model for maximum thoroughness. Findings are verified before compilation, then compiled into a unified report sorted by severity with a phased repair roadmap.
 
 ## Core Principles
 
-1. **Opus only** — All audit agents MUST use `model="opus"`. This is non-negotiable. Smaller models miss subtle cross-file issues.
+1. **Highest-tier model** — All audit agents MUST use the highest-capability model available in the current environment (e.g. `fable`; `opus` acceptable as fallback). Never use lightweight tiers (haiku) for audit agents. If the highest tier is unavailable, fall back one tier and note the downgrade in the report header.
 2. **Depth over breadth** — Fewer agents with broader scope and deeper analysis beats many shallow agents. Each agent should trace issues across file boundaries.
 3. **Adaptive** — Agent count and focus areas vary by project type. Don't waste an agent on "frontend rendering" for a backend-only project.
+4. **Verify before report** — No Critical/High finding enters the report unverified. LLM audit agents misreport intentional patterns (deliberate fallbacks, feature gates) as defects; Phase 1.5 exists to catch that.
 
 ## When to Use
 
@@ -19,11 +20,11 @@ A comprehensive codebase audit that adapts its agent configuration to the projec
 - User wants to find hidden bugs, silent degradation, or design inconsistencies
 - User asks about technical debt, architecture health, or "what's broken"
 - Before a major refactor or after inheriting an unfamiliar codebase
-- Periodic health check (monthly/quarterly)
+- Periodic health check (monthly/quarterly) — see Phase 3 for baseline diffing
 
 ## Workflow
 
-### Phase 0: Tech Stack Detection
+### Phase 0: Tech Stack Detection & Deterministic Scans
 
 Detect the project's tech stack to determine the agent configuration:
 
@@ -34,13 +35,27 @@ Detection checklist:
 - Cargo.toml → Rust (serde, axum, actix, etc.)
 - go.mod → Go (gin, echo, gorm, etc.)
 - Multiple stacks → Full-stack project (frontend + backend)
+- Async runtime signals: Cargo.toml contains tokio/async-std, go.mod present,
+  asyncio imports → enable the Concurrency & Async Hygiene section for the
+  Data Integrity agent (see agent-prompts.md)
 ```
+
+After stack detection, run the matching dependency audit (deterministic, zero LLM cost):
+
+```
+- Rust → cargo audit       - Node → npm audit
+- Python → pip-audit       - Go → govulncheck ./...
+```
+
+Feed the raw output to the Error Handling & Security agent (frontend-only: to Agent 2) for classification: Critical = RCE-grade CVE with PoC on a reachable path; High = known vuln on a reachable path. If the tool is unavailable, the report MUST state "依赖审计降级跳过" — never omit silently.
 
 ### Phase 1: Launch Agents (Adaptive)
 
-Based on the detected stack, choose the appropriate agent configuration below. Launch ALL agents in a SINGLE message with `model="opus"` for every agent.
+Based on the detected stack, choose the appropriate agent configuration below. Launch ALL agents in a SINGLE message, each with the model tier defined in Core Principles #1.
 
-Read `references/agent-prompts.md` for complete prompt templates.
+Read `references/agent-prompts.md` for complete prompt templates. Every prompt MUST be self-contained: target path, stack info, and the Unified Output Contract (defined at the top of agent-prompts.md) — sub-agents cannot see this file.
+
+Before launching, verify every agent Type against the available subagent registry. If a type is not registered, STOP and report the missing type — do NOT substitute a similar one.
 
 ---
 
@@ -50,10 +65,10 @@ When both frontend and backend exist (e.g., React + FastAPI, Next.js + Go).
 
 | # | Agent | Type | Scope (merged dimensions) |
 |---|-------|------|---------------------------|
-| 1 | **Frontend-Backend Contract** | `reviewer` | Type consistency (field names, types, missing fields) + Rendering pipeline (layout/block/card routing completeness, dead slots, unrendered fields) + Serialization boundaries (models that silently drop fields). This agent reads BOTH sides and traces data across the API boundary. |
-| 2 | **Data Integrity & Flow** | `code-reviewer` | Data pipeline end-to-end: from input through every transformation layer to output. Covers: field resolver filters, serialization/deserialization, model_validate/model_dump, cache read/write symmetry. Finds where fields get silently dropped. Also covers: declaration-execution gaps (registered but unwired handlers, enum without config). |
-| 3 | **Error Handling & Security** | `security-reviewer` | Exception patterns (bare except, debug-level errors, warning+fallback), security (hardcoded secrets, injection, unsafe deserialization), silent degradation (error paths that produce user-visible wrong output instead of failing). |
-| 4 | **Architecture & Code Quality** | `architect` | Layer violations, circular dependencies, god objects (files >800 lines), code duplication (parallel systems, scattered mapping tables), extension cost analysis (how many files to add a new type), DI pattern consistency. |
+| 1 | **Frontend-Backend Contract** | `code-reviewer` | Type consistency (field names, types, missing fields) + Rendering pipeline (layout/block/card routing completeness, dead slots, unrendered fields) + Serialization boundaries (models that silently drop fields). This agent reads BOTH sides and traces data across the API boundary. |
+| 2 | **Data Integrity & Flow** | `code-reviewer` | Data pipeline end-to-end: from input through every transformation layer to output. Covers: field resolver filters, serialization/deserialization, model_validate/model_dump, cache read/write symmetry, registry key-set alignment (sole owner — Agent 4 must not re-check). Also covers: declaration-execution gaps (registered but unwired handlers, enum without config), and Concurrency & Async Hygiene when an async runtime is detected. |
+| 3 | **Error Handling & Security** | `security-reviewer` | Exception patterns (bare except, debug-level errors, warning+fallback), security (hardcoded secrets, injection, unsafe deserialization), silent degradation (error paths that produce user-visible wrong output instead of failing), classification of Phase 0 dependency-audit output. |
+| 4 | **Architecture & Code Quality** | `architect` | Layer violations, circular dependencies, god objects (files >800 lines), code duplication (parallel systems, scattered mapping tables), extension cost analysis (how many files to add a new type), DI pattern consistency, test quality (coverage gaps, weakened assertions, skip markers, stale tests). |
 | 5 | **Config & Persistence** | `database-reviewer` | Config completeness (template/schema vs code expectations, conflicting defaults), cache key completeness (missing code version dimension), DB schema consistency, temp file cleanup, state persistence across restarts. |
 
 ---
@@ -64,7 +79,7 @@ When only backend exists (Python API, Rust service, Go microservice, etc.)
 
 | # | Agent | Type | Scope |
 |---|-------|------|-------|
-| 1 | **API Contract & Data Integrity** | `code-reviewer` | API schema vs internal models, serialization boundaries, data pipeline tracing, field dropping, declaration-execution gaps. |
+| 1 | **API Contract & Data Integrity** | `code-reviewer` | API schema vs internal models, serialization boundaries, data pipeline tracing, field dropping, registry key-set alignment, declaration-execution gaps, concurrency hygiene when async runtime detected. |
 | 2 | **Error Handling & Security** | `security-reviewer` | Same as full-stack Agent 3. |
 | 3 | **Architecture & Code Quality** | `architect` | Same as full-stack Agent 4. |
 | 4 | **Config & Persistence** | `database-reviewer` | Same as full-stack Agent 5. |
@@ -77,15 +92,31 @@ When only frontend exists (React SPA, Vue app, etc.)
 
 | # | Agent | Type | Scope |
 |---|-------|------|-------|
-| 1 | **Component Architecture & Rendering** | `reviewer` | Type routing completeness, component registration gaps, dead props/slots, state management consistency, API consumption patterns. |
-| 2 | **Error Handling & Code Quality** | `code-reviewer` | Unhandled promise rejections, error boundaries, catch-and-ignore patterns, god components, code duplication. |
-| 3 | **Config & Build** | `reviewer` | Build config consistency, env variable management, bundle analysis, dead dependencies. |
+| 1 | **Component Architecture & Rendering** | `code-reviewer` | Type routing completeness, component registration gaps, dead props/slots, state management consistency, API consumption patterns, minimal accessibility checks (alt/label/keyboard reachability). |
+| 2 | **Error Handling & Code Quality** | `code-reviewer` | Unhandled promise rejections, error boundaries, catch-and-ignore patterns, god components, code duplication, test quality, dependency-audit classification. |
+| 3 | **Config & Build** | `general-purpose` | Build config consistency, env variable management, bundle analysis, dead dependencies. |
 
 ---
 
+### Phase 1.5: Verify Findings
+
+For every Critical and High finding:
+
+1. Spawn 1-2 verifier agents (same model tier). Input = ONLY the finding's claim + involved file paths (minimal context).
+2. The verifier must actively search for counter-evidence: test coverage, feature flags, intentional-design comments, call sites that handle the "missing" case.
+3. Verdict: confirm / refute / uncertain, with reasons.
+4. Refuted findings move to a report appendix "已排除项" with the refutation reason (do NOT delete).
+5. Medium findings: spot-check ≥30%.
+
+Critical findings MUST be 已复核 before entering "Fix Immediately".
+
 ### Phase 2: Compile Unified Report
 
-After ALL agents complete, compile findings into a single report:
+After verification completes, compile findings into a single report.
+
+> 报告正文（问题描述、影响分析、修复建议）一律使用中文；代码片段、文件路径、标识符、错误消息保留原文。
+>
+> 每条发现按三层呈现：发现本体 = 事实（带 file:line）；影响分析 = 推断（带置信度，evidence_type 为 inferred 的不得高于 medium）；修复建议 = 建议（带前提假设）。
 
 ```markdown
 # [Project Name] Codebase Audit Report
@@ -93,28 +124,31 @@ After ALL agents complete, compile findings into a single report:
 > Audit date: YYYY-MM-DD
 > Target: path
 > Tech stack: detected stack
-> Agents: N (list agent names)
+> Agents: N (list agent names) | Model tier: (note any downgrade)
+> Dependency audit: ran / 依赖审计降级跳过
 
 ## Summary
 | Level | Count | Key Areas |
 |-------|-------|-----------|
 | Critical | N | ... |
-| High/P1 | N | ... |
-| Medium/P2 | N | ... |
+| High | N | ... |
+| Medium | N | ... |
 
 ## Critical (Fix Immediately)
-| # | Problem | Agent | Impact |
-|---|---------|-------|--------|
-For each: file:line, code snippet, risk description, fix suggestion.
+| # | Problem | Agent | Impact | evidence_type | confidence | 验证状态 |
+|---|---------|-------|--------|---------------|------------|----------|
+For each: file:line, code snippet, risk description (推断需标注置信度), fix suggestion (标注前提).
 
-## High / P1 (Fix This Week)
+## High (Fix This Week)
 ### [Category]
-| # | Problem | File(s) |
-|---|---------|---------|
-Details for each.
+[Same columns as Critical]
 
-## Medium / P2 (Plan to Fix)
+## Medium (Plan to Fix)
 [Same structure]
+
+## 已排除项 (Refuted in Phase 1.5)
+| # | Original claim | Refutation reason |
+|---|----------------|-------------------|
 
 ## Repair Roadmap
 | Phase | Scope | Est. Files |
@@ -123,23 +157,45 @@ Details for each.
 | Phase 1 (this week) | High priority | ~N files |
 | Phase 2 (next week) | Medium priority | ~N files |
 | Phase 3 (ongoing) | Architecture | ~N files |
+
+Est. Files = 该级别所有发现 files 字段去重并集大小；若修复涉及发现位置之外的文件，可追加估算但必须标注「推断，置信度低」。
 ```
 
 ### Deduplication
 
-Since agents have broader overlapping scopes, deduplication is simpler:
+All agents emit the Unified Output Contract table (see agent-prompts.md), so the severity scale and the `files` dedup key are consistent across agents:
+
 - Same file + same line → merge
 - Same root cause found by multiple agents → keep the most detailed one, note cross-agent confirmation (this actually increases confidence)
-- Severity conflicts → use the highest
+- Severity conflicts → use the highest (scales are unified, so this is mechanical)
 
 ### Severity Classification
 
-| Level | Criteria |
-|-------|----------|
-| **Critical** | Data loss, rendering failure, security vulnerability, complete feature breakage affecting users NOW |
-| **High/P1** | Silent degradation (user sees wrong/incomplete output), type mismatches causing data truncation, missing config causing empty output, architectural violations blocking development |
-| **Medium/P2** | Code duplication, inconsistent patterns, suboptimal error handling, tech debt that slows development but doesn't break features |
+The authoritative severity rubric lives in the **Unified Output Contract** at the top of `references/agent-prompts.md` — it must be inside the prompts because sub-agents cannot see this file. Do not redefine it here; Phase 2 uses the same four levels (Critical / High / Medium / Low).
+
+### Phase 3: Baseline Diff (periodic health checks)
+
+Persist artifacts after every audit:
+
+- `<target>/.audit/report-YYYY-MM-DD.md`
+- `<target>/.audit/findings-YYYY-MM-DD.json` — the structured finding table
+- Stable finding ID: `hash(category + 归一化文件路径 + title 关键词)` (robust to line drift)
+- `<target>/.audit/false-positives.json` — user-marked false positives; filter or downweight matching findings during the next compile step
+
+When a previous `findings-*.json` exists, add a baseline diff section:
+
+| 状态 | 定义 |
+|---|---|
+| 已修复 | 上次有、本次无（需复核确认，不默认已修） |
+| 仍存在 | 两次都有（标注存活轮数） |
+| 新增 | 本次新出现 |
+
+Summary 表增加环比列。
 
 ## Stack-Specific Patterns
 
 Read `references/stack-patterns.md` for technology-specific search patterns.
+
+## Evals
+
+`evals/evals.json` contains trigger/output test cases — keep `expected_output` in sync whenever the agent configuration or report format changes (a past 10-agent → 5-agent refactor left them stale and permanently failing).

--- a/skills/codebase-audit/evals/evals.json
+++ b/skills/codebase-audit/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "codebase-audit",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "帮我全面审查一下 /Users/lifcc/Desktop/code/work/mutil-om 这个项目的设计问题",
+      "expected_output": "按检测到的技术栈启动对应数量的并行 agent（全栈 5 / 后端 4 / 前端 3），agent 类型全部来自真实注册表；Critical/High 发现经 Phase 1.5 复核后输出 Critical/High/Medium 分级统一报告（含 evidence_type/confidence/验证状态列）+ 修复路线图",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "/codebase-audit /Users/lifcc/Desktop/code/work/mutil-om",
+      "expected_output": "同 eval 1，通过 slash command 触发；agent 数量与检测到的栈类型匹配",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "这个代码库有哪些隐藏问题？前后端类型对不对得上？有没有静默降级？",
+      "expected_output": "自然语言触发审计；全栈项目应启动 5 个 agent（含 Frontend-Backend Contract 维度），报告正文为中文，发现按 事实/推断/建议 分层并带置信度",
+      "files": []
+    }
+  ]
+}

--- a/skills/codebase-audit/references/agent-prompts.md
+++ b/skills/codebase-audit/references/agent-prompts.md
@@ -21,6 +21,7 @@ Every agent MUST end its report with findings in this exact Markdown table, one 
   - Low: informational / style-level findings
 - files: every involved `path:line`, comma-separated (this is the dedup key — mandatory)
 - evidence: code snippet ≤3 lines
+- Table cells must stay parseable: replace newlines inside cells with `<br>` and escape literal pipe characters as `\|` in every cell, especially `evidence`.
 - evidence_type: `observed` (directly visible in code) / `inferred` (cross-file reasoning)
 - confidence: high / medium / low (inference chains >2 steps MUST be ≤ medium)
 - Max 25 findings. If zero findings, write `NO_FINDINGS` and list the patterns you searched.
@@ -32,7 +33,7 @@ Every agent MUST end its report with findings in this exact Markdown table, one 
 
 ## Full-Stack Configuration (5 agents)
 
-### Agent 1: Frontend-Backend Contract (code-reviewer)
+### Agent 1: Frontend-Backend Contract (senior-code-reviewer)
 
 ```
 Deep audit of {TARGET_DIR} for frontend-backend contract consistency.
@@ -67,7 +68,7 @@ For every finding, `files` must include BOTH sides (frontend AND backend path:li
 [Unified Output Contract]
 ```
 
-### Agent 2: Data Integrity & Flow (code-reviewer)
+### Agent 2: Data Integrity & Flow (senior-code-reviewer)
 
 ```
 Deep audit of {TARGET_DIR} for data pipeline integrity.
@@ -139,7 +140,7 @@ For data-flow findings, `files` must include the full path (source → transform
 [Unified Output Contract]
 ```
 
-### Agent 3: Error Handling & Security (security-reviewer)
+### Agent 3: Error Handling & Security (security-auditor)
 
 ```
 Deep audit of {TARGET_DIR} for exception handling and security issues.
@@ -183,7 +184,7 @@ Mark these findings evidence_type = observed (tool output is evidence).
 [Unified Output Contract]
 ```
 
-### Agent 4: Architecture & Code Quality (architect)
+### Agent 4: Architecture & Code Quality (code-archaeologist)
 
 ```
 Deep audit of {TARGET_DIR} for architectural issues and technical debt.
@@ -224,12 +225,12 @@ Note: Registry key-set alignment is owned by the Data Integrity agent — do not
 1. Multiple dependency injection patterns in use? (global state, factory, constructor mixed)
 2. Inconsistent error handling patterns across modules
 
-End with an "Extension Cost" table in addition to the findings table.
+If useful, include an "Extension Cost" table before the final findings table. The report must still end with the Unified Output Contract findings table; do not place any extra table or prose after it.
 
 [Unified Output Contract]
 ```
 
-### Agent 5: Config & Persistence (database-reviewer)
+### Agent 5: Config & Persistence (code-archaeologist)
 
 ```
 Deep audit of {TARGET_DIR} for configuration and persistence issues.
@@ -270,7 +271,7 @@ Tech stack: {STACK_INFO}
 
 Use Agent 3, 4, 5 from the full-stack config unchanged. Agent 1 below replaces both full-stack Agent 1 and Agent 2 — its content is fully inlined so the prompt works with zero external context:
 
-### Agent 1: API Contract & Data Integrity (code-reviewer)
+### Agent 1: API Contract & Data Integrity (senior-code-reviewer)
 
 ```
 Deep audit of {TARGET_DIR} for API contract and data integrity.
@@ -326,7 +327,7 @@ For data-flow findings, `files` must include the full path (source → transform
 
 ## Frontend-Only Configuration (3 agents)
 
-### Agent 1: Component Architecture & Rendering (code-reviewer)
+### Agent 1: Component Architecture & Rendering (senior-code-reviewer)
 
 ```
 Deep audit of {TARGET_DIR} for component architecture and rendering integrity.
@@ -346,7 +347,7 @@ Tech stack: {STACK_INFO}
 [Unified Output Contract]
 ```
 
-### Agent 2: Error Handling & Code Quality (code-reviewer)
+### Agent 2: Error Handling & Code Quality (senior-code-reviewer)
 
 ```
 Deep audit of {TARGET_DIR} for error handling and code quality.
@@ -367,7 +368,7 @@ Tech stack: {STACK_INFO}
 [Unified Output Contract]
 ```
 
-### Agent 3: Config & Build (general-purpose)
+### Agent 3: Config & Build (code-archaeologist)
 
 ```
 Deep audit of {TARGET_DIR} for build configuration and dependency hygiene.

--- a/skills/codebase-audit/references/agent-prompts.md
+++ b/skills/codebase-audit/references/agent-prompts.md
@@ -1,14 +1,38 @@
 # Agent Prompt Templates
 
-**CRITICAL: All agents MUST be launched with `model="opus"`.** Never downgrade to sonnet or haiku.
+**Model policy: see SKILL.md Core Principles #1** (highest-tier model for every audit agent).
 
-Replace `{TARGET_DIR}` and `{STACK_INFO}` based on detected stack. Adapt technology-specific sections accordingly.
+Replace `{TARGET_DIR}` and `{STACK_INFO}` based on detected stack. Adapt technology-specific sections accordingly. Every template MUST be sent self-contained — sub-agents cannot see SKILL.md or this file's other sections, so always append the Unified Output Contract below to every prompt.
+
+---
+
+## Unified Output Contract (append to EVERY agent prompt)
+
+```
+Every agent MUST end its report with findings in this exact Markdown table, one row per finding:
+
+| severity | title | files | evidence | evidence_type | confidence | impact | fix |
+|---|---|---|---|---|---|---|---|
+
+- severity: Critical / High / Medium / Low — use this rubric:
+  - Critical: data loss, rendering failure, security vulnerability, complete feature breakage affecting users NOW
+  - High: silent degradation (user sees wrong/incomplete output), type mismatch causing truncation, missing config causing empty output, architectural violations blocking development
+  - Medium: code duplication, inconsistent patterns, suboptimal error handling, tech debt that slows development
+  - Low: informational / style-level findings
+- files: every involved `path:line`, comma-separated (this is the dedup key — mandatory)
+- evidence: code snippet ≤3 lines
+- evidence_type: `observed` (directly visible in code) / `inferred` (cross-file reasoning)
+- confidence: high / medium / low (inference chains >2 steps MUST be ≤ medium)
+- Max 25 findings. If zero findings, write `NO_FINDINGS` and list the patterns you searched.
+- Write all finding descriptions in Chinese; keep code identifiers, paths, and error messages as-is.
+- No prose summaries outside the table.
+```
 
 ---
 
 ## Full-Stack Configuration (5 agents)
 
-### Agent 1: Frontend-Backend Contract (reviewer)
+### Agent 1: Frontend-Backend Contract (code-reviewer)
 
 ```
 Deep audit of {TARGET_DIR} for frontend-backend contract consistency.
@@ -38,7 +62,9 @@ For each model that participates in serialization/deserialization:
 1. Does it silently drop unknown fields? (Pydantic extra="ignore", serde default, Zod strict)
 2. Is it on a cache/LLM/API hot path where field dropping causes user-visible issues?
 
-Output: Findings sorted by severity. For each: both file:line references (frontend AND backend).
+For every finding, `files` must include BOTH sides (frontend AND backend path:line).
+
+[Unified Output Contract]
 ```
 
 ### Agent 2: Data Integrity & Flow (code-reviewer)
@@ -79,7 +105,7 @@ Trace data from input to output through every transformation layer:
 3. Generation mode declarations (e.g., "deterministic" vs "llm") that contradict code behavior
 4. Registered but never-called methods (persist/save/restore that no startup code invokes)
 
-### Registry Coverage Alignment (critical — easy to miss)
+### Registry Coverage Alignment (critical — easy to miss; you are the SOLE owner of this check)
 This is the hardest class of bug to find: two dicts/maps/registries that SHOULD have the same key set but DON'T. The system works for the keys that overlap but silently does nothing for the missing ones.
 
 Pattern to search for:
@@ -92,13 +118,25 @@ Examples of what this catches:
 - SectionType enum has 25 values but fieldConfig only has 20 → 5 sections get empty data from FieldResolver
 - DETERMINISTIC_SECTION_BUILDERS has 18 entries but ROUTABLE_SECTION_BUILDERS has 14 → 4 sections can't route
 
-For each pair of registries that share a key type, output:
-- Registry A: file:line, N keys
-- Registry B: file:line, M keys
+For each pair of registries that share a key type, the finding must list:
+- Registry A: file:line, N keys / Registry B: file:line, M keys
 - Missing in B: [list of keys]
 - Impact: what happens when a key is in A but not B
 
-Output: Each finding with the full data path (source file:line → transform file:line → destination file:line).
+### Concurrency & Async Hygiene (only when Phase 0 detected an async runtime)
+Only report statically provable items with file:line evidence. NO speculative performance guesses.
+1. Lock guards held across .await (std::sync::Mutex/RwLock guard crossing an await point)
+2. tokio::spawn with discarded JoinHandle / no panic propagation
+3. unbounded_channel and unbounded queues on hot paths
+4. Arc<Mutex<HashMap>> hot write contention
+5. Go: goroutines with no exit path; concurrent map writes
+6. Blocking calls inside async context: std::fs, reqwest::blocking, thread::sleep
+7. Per-item DB/HTTP calls inside loops (N+1)
+8. Grow-only caches/collections (insert with no eviction)
+
+For data-flow findings, `files` must include the full path (source → transform → destination).
+
+[Unified Output Contract]
 ```
 
 ### Agent 3: Error Handling & Security (security-reviewer)
@@ -135,7 +173,14 @@ The most dangerous pattern: errors that produce WRONG output instead of failing.
 6. Sensitive data in logs
 7. CORS misconfiguration (origins: ["*"] in production)
 
-Output: Sorted by severity, each with file:line and code snippet.
+### Dependency Audit Classification (when Phase 0 output is provided)
+Classify the attached dependency-audit tool output:
+- Critical = RCE-grade CVE with PoC on a reachable path
+- High = known vuln on a reachable path
+- Medium = known vuln, reachability unclear
+Mark these findings evidence_type = observed (tool output is evidence).
+
+[Unified Output Contract]
 ```
 
 ### Agent 4: Architecture & Code Quality (architect)
@@ -167,15 +212,21 @@ Tech stack: {STACK_INFO}
 Calculate: how many files must change to add a new [type/variant/feature]?
 List the exact files for the most common extension operation.
 
-### Registry Cross-Reference
-Find all module-level dicts/maps that act as registries for the same key type. Compare their key sets. This catches "works for 10 items but silently skips 14" bugs — the hardest to find because no error is thrown.
+Note: Registry key-set alignment is owned by the Data Integrity agent — do not re-check it.
+
+### Test Quality
+1. Business-logic modules with no matching test file / #[cfg(test)] block — list them
+2. Weakened assertions: assertTrue wrapping, containment instead of exact match
+3. Skip markers without justification: pytest.mark.skip, test.skip, #[ignore]
+4. Test-stale: tests referencing signatures that no longer match the code under test
 
 ### DI & Pattern Consistency
 1. Multiple dependency injection patterns in use? (global state, factory, constructor mixed)
 2. Inconsistent error handling patterns across modules
 
-Output: Each finding with [P0/P1/P2] severity, file(s), and impact description.
-End with an "Extension Cost" table.
+End with an "Extension Cost" table in addition to the findings table.
+
+[Unified Output Contract]
 ```
 
 ### Agent 5: Config & Persistence (database-reviewer)
@@ -210,14 +261,14 @@ Tech stack: {STACK_INFO}
 4. File paths — hardcoded relative paths that depend on cwd?
 5. TTL cleanup — consistent semantics across all stores?
 
-Output: Sorted by severity with file:line references.
+[Unified Output Contract]
 ```
 
 ---
 
 ## Backend-Only Configuration (4 agents)
 
-Use Agent 2, 3, 4, 5 from full-stack config. Replace Agent 1 with:
+Use Agent 3, 4, 5 from the full-stack config unchanged. Agent 1 below replaces both full-stack Agent 1 and Agent 2 — its content is fully inlined so the prompt works with zero external context:
 
 ### Agent 1: API Contract & Data Integrity (code-reviewer)
 
@@ -226,51 +277,109 @@ Deep audit of {TARGET_DIR} for API contract and data integrity.
 
 Tech stack: {STACK_INFO}
 
-Combines: API schema consistency, serialization boundaries, data flow tracing, declaration-execution gaps.
-
+### API Contract
 1. API response models vs internal domain models — field mismatches?
 2. Serialization models (Pydantic/serde/Zod) — do they silently drop fields?
-3. Data pipeline tracing (same as full-stack Agent 2)
-4. Declaration-execution gaps (same as full-stack Agent 2)
+   (Pydantic extra="ignore", serde missing deny_unknown_fields, struct tags missing)
+3. Enum/union values — all variants handled at every consumption site?
 
-Output: Each finding with full data path and severity.
+### Data Flow Tracing
+Trace data from input to output through every transformation layer:
+1. Input → extraction/validation — where do fields first get filtered?
+   Field resolvers that only pass declared fields; schema validators that strip unknown fields.
+2. Extraction → context building — fields injected by orchestrator but not declared in
+   config get silently dropped by resolvers; watch for TWO parallel injection mechanisms.
+3. Context → builder/generator — search for context.get("field_name") calls and
+   cross-reference with what's actually in the context at that point.
+4. Builder → serialization — model_dump(exclude_none=True) drops None fields;
+   are all by_alias names correct?
+5. Serialization → cache — cache key completeness (code version? prompt version?);
+   cache deserialization wrapped in try/except or crashes on schema change?
+
+### Declaration-Execution Integrity
+1. Registered handlers/builders without corresponding implementation
+2. Enum values without config entries, config entries without code
+3. Generation mode declarations contradicting code behavior
+4. Registered but never-called methods (persist/save/restore that no startup code invokes)
+
+### Registry Coverage Alignment (you are the SOLE owner of this check)
+Find all module-level dicts/maps/match statements sharing a key type; compare key sets
+pairwise; flag any registry with fewer keys than the source-of-truth registry. For each
+pair, list both file:line locations, the missing keys, and the runtime impact.
+
+### Concurrency & Async Hygiene (only when Phase 0 detected an async runtime)
+Only report statically provable items. NO speculative performance guesses.
+1. Lock guards held across .await
+2. tokio::spawn with discarded JoinHandle
+3. unbounded channels/queues on hot paths
+4. Go: goroutines with no exit path; concurrent map writes
+5. Blocking calls inside async context (std::fs, reqwest::blocking, thread::sleep)
+6. Per-item DB/HTTP calls inside loops (N+1)
+7. Grow-only caches/collections
+
+For data-flow findings, `files` must include the full path (source → transform → destination).
+
+[Unified Output Contract]
 ```
 
 ---
 
 ## Frontend-Only Configuration (3 agents)
 
-### Agent 1: Component Architecture & Rendering (reviewer)
+### Agent 1: Component Architecture & Rendering (code-reviewer)
 
 ```
-Deep audit of {TARGET_DIR} for component architecture.
+Deep audit of {TARGET_DIR} for component architecture and rendering integrity.
 
-1. Type routing completeness — all possible types have renderers?
+Tech stack: {STACK_INFO}
+
+1. Type routing completeness — all possible types have renderers? What happens with
+   unknown types: crash, blank, or graceful fallback?
 2. Component registration — dead components, missing registrations?
+   Check switch(type)/if-else routing chains for exhaustiveness.
 3. Props consumed but never provided? Props provided but never consumed?
 4. State management — inconsistent patterns, prop drilling, stale state?
 5. API consumption — error handling for API calls, loading states, empty states?
+6. Minimal accessibility pass: images without alt, form controls without labels,
+   interactive elements unreachable by keyboard.
 
-Output: Sorted by severity.
+[Unified Output Contract]
 ```
 
 ### Agent 2: Error Handling & Code Quality (code-reviewer)
 
 ```
-1. Unhandled promise rejections, empty catch blocks
-2. Error boundaries coverage
-3. God components (>300 lines), code duplication
-4. Accessibility issues
+Deep audit of {TARGET_DIR} for error handling and code quality.
 
-Output: Sorted by severity.
+Tech stack: {STACK_INFO}
+
+1. Unhandled promise rejections — search: .then( without .catch, async functions
+   without try/catch at call sites
+2. Empty catch blocks — search: catch(e) {}, .catch(() => {}), catch (_)
+3. Error boundaries — list route-level components without an ErrorBoundary wrapper
+4. God components (>300 lines) — list each with line count
+5. Code duplication — parallel components doing the same job
+6. Test quality — components with logic but no test file; weakened assertions;
+   test.skip without justification
+7. Dependency audit classification (when Phase 0 npm audit output is provided):
+   Critical = RCE-grade CVE on a reachable path; High = known vuln on a reachable path
+
+[Unified Output Contract]
 ```
 
-### Agent 3: Config & Build (reviewer)
+### Agent 3: Config & Build (general-purpose)
 
 ```
-1. Build config consistency, dead dependencies
-2. Environment variable management
-3. Bundle size issues (large imports, tree-shaking failures)
+Deep audit of {TARGET_DIR} for build configuration and dependency hygiene.
 
-Output: Sorted by severity.
+Tech stack: {STACK_INFO}
+
+1. Build config consistency — conflicting settings across tsconfig/vite/webpack configs
+2. Dead dependencies — packages in package.json never imported
+3. Environment variable management — env vars referenced in code but missing from
+   .env.example; secrets committed in env files
+4. Bundle size issues — large imports (full lodash/moment), tree-shaking failures,
+   missing code splitting on routes
+
+[Unified Output Contract]
 ```

--- a/skills/codebase-audit/references/stack-patterns.md
+++ b/skills/codebase-audit/references/stack-patterns.md
@@ -1,54 +1,51 @@
 # Stack-Specific Search Patterns
 
-Quick reference for each agent to adapt its searches based on the detected tech stack.
+Quick reference for each agent to adapt its searches based on the detected tech stack. The "Agent" column uses the current dimension names from SKILL.md (Frontend-Backend Contract / Data Integrity & Flow / Error Handling & Security / Architecture & Code Quality / Config & Persistence).
 
 ## Python + Pydantic + FastAPI
 
 | Agent | Key Search Patterns |
 |-------|-------------------|
-| Type Consistency | `Field(alias=...)` values, `model_dump(by_alias=True)` output keys |
-| Declaration-Execution | `@app.get/post`, dependency injection `Depends()`, `include_router()` |
-| Data Flow | `model_validate()`, `model_dump(exclude_none=True)`, `extra="ignore"` |
-| Serialization | `class X(BaseModel)`, check `model_config` for `extra` setting |
-| Exception | `except Exception: pass`, `logger.debug` for errors, `logger.warning + return` |
-| Cache | `hashlib`, cache key construction, `pickle.dumps/loads` |
-| Config | `os.getenv()`, `.env` files, `Settings(BaseSettings)` |
+| Frontend-Backend Contract | `Field(alias=...)` values, `model_dump(by_alias=True)` output keys |
+| Data Integrity & Flow | `model_validate()`, `model_dump(exclude_none=True)`, `extra="ignore"`, `@app.get/post`, `Depends()`, `include_router()` |
+| Error Handling & Security | `except Exception: pass`, `logger.debug` for errors, `logger.warning + return` |
+| Architecture & Code Quality | files >800 lines, classes >15 methods; tests: `pytest.mark.skip`, bare `assertTrue`, missing `test_*.py` for logic modules |
+| Config & Persistence | `os.getenv()`, `.env` files, `Settings(BaseSettings)`, `hashlib` cache keys, `pickle.dumps/loads` |
 
 ## TypeScript + React
 
 | Agent | Key Search Patterns |
 |-------|-------------------|
-| Type Consistency | `interface X`, `type X =`, compare with backend model fields |
-| Declaration-Execution | Component registry, route definitions, `switch(type)` exhaustiveness |
-| Rendering | `props?.fieldName`, component `switch/if-else` chains for type routing |
-| Serialization | Zod schemas (`.strict()` vs `.passthrough()`), `as` type assertions |
-| Exception | `catch(e) {}`, `.catch(() => {})`, unhandled promise rejections |
+| Frontend-Backend Contract | `interface X`, `type X =`, compare with backend model fields; Zod `.strict()` vs `.passthrough()`, `as` type assertions |
+| Data Integrity & Flow | Component registry, route definitions, `switch(type)` exhaustiveness, `props?.fieldName` routing chains |
+| Error Handling & Security | `catch(e) {}`, `.catch(() => {})`, unhandled promise rejections |
+| Architecture & Code Quality | God components >300 lines; tests: `test.skip`/`it.skip`, `toBeTruthy()` wrapping, missing `*.test.tsx` |
+| Config & Persistence | env vars not in `.env.example`, conflicting tsconfig/bundler settings |
 
 ## Rust + serde + axum/actix
 
 | Agent | Key Search Patterns |
 |-------|-------------------|
-| Type Consistency | `#[serde(rename=...)]`, `#[serde(rename_all=...)]` |
-| Declaration-Execution | `impl Trait for X`, `Router::new().route()`, `mod` declarations |
-| Data Flow | `#[serde(skip_serializing_if)]`, `#[serde(default)]` |
-| Serialization | `#[serde(deny_unknown_fields)]` absence, `serde_json::from_str` |
-| Exception | `let _ = expr`, `unwrap()`, `.ok()` discarding errors |
-| God Objects | `impl X { }` with >15 methods, files >800 lines |
+| Frontend-Backend Contract | `#[serde(rename=...)]`, `#[serde(rename_all=...)]` |
+| Data Integrity & Flow | `#[serde(skip_serializing_if)]`, `#[serde(default)]`, `#[serde(deny_unknown_fields)]` absence, `serde_json::from_str`, `impl Trait for X`, `Router::new().route()`; concurrency: `std::sync::Mutex` guard across `.await`, `tokio::spawn(` with discarded handle, `unbounded_channel`, `reqwest::blocking`/`std::fs` in async fn |
+| Error Handling & Security | `let _ = expr`, `unwrap()`, `.ok()` discarding errors |
+| Architecture & Code Quality | `impl X { }` with >15 methods, files >800 lines; tests: `#[ignore]`, `assert!(true)`, modules without `#[cfg(test)]` |
+| Config & Persistence | config structs never `load()`ed (only `Default::default()`), cache key construction |
 
 ## Go + gin/echo
 
 | Agent | Key Search Patterns |
 |-------|-------------------|
-| Type Consistency | `json:"field_name"` struct tags, compare with frontend types |
-| Declaration-Execution | `r.GET/POST()` route registrations, interface implementations |
-| Data Flow | `json.Marshal/Unmarshal`, `omitempty` tags, struct embedding |
-| Serialization | Missing `json` tags (Go exports uppercase but JSON uses lowercase) |
-| Exception | `if err != nil { return }` without logging, `_ = expr` |
+| Frontend-Backend Contract | `json:"field_name"` struct tags, compare with frontend types; missing `json` tags (Go exports uppercase but JSON uses lowercase) |
+| Data Integrity & Flow | `json.Marshal/Unmarshal`, `omitempty` tags, struct embedding, `r.GET/POST()` route registrations, interface implementations; concurrency: `go func(` without exit path, concurrent map writes, channels without close |
+| Error Handling & Security | `if err != nil { return }` without logging, `_ = expr` |
+| Architecture & Code Quality | files >800 lines; tests: `t.Skip(` without reason, missing `_test.go` for logic packages |
+| Config & Persistence | `os.Getenv` outside config package, hardcoded defaults |
 
 ## Full-Stack Projects
 
 When both frontend and backend are detected:
-- Agent 1 (Type Consistency) becomes the most critical — compare BOTH sides
-- Agent 7 (Rendering Pipeline) is fully active
-- Agent 3 (Duplication) should specifically check for cross-stack duplication (same constants, enums, validation rules defined in both)
-- Agent 4 (Data Flow) should trace data across the API boundary
+
+- The **Frontend-Backend Contract agent** is the most critical — it must compare BOTH sides of every shared type and owns the full rendering-pipeline check.
+- The **Data Integrity & Flow agent** should trace data across the API boundary, not stop at the serialization layer.
+- The **Architecture & Code Quality agent** should specifically check for cross-stack duplication (same constants, enums, validation rules defined in both Python/Go and TypeScript).


### PR DESCRIPTION
Closes #56

修复 #56 中的全部 3 个 P0 + 8 个 P1（含 1 个零成本 P2 项）。P2 其余项（大仓分片、补扫循环、EXCLUDE_DIRS 占位符、token 预算）留作后续。

## P0 — 失效引用与事实性错误

- **agent type `reviewer` 不存在** → 全栈 Agent 1 / 前端 Agent 1 改 `code-reviewer`，前端 Agent 3 改 `general-purpose`；Phase 1 新增防御规则：spawn 前核对注册表，类型缺失时 STOP 而非静默替换近似类型
- **10-agent 旧设计残留** → stack-patterns.md 删除 "Agent 7" 等失效编号，Agent 列全部改为现行 5 维度名并按合并关系归并旧行；evals.json 的「10 维度」期望改为可验证的 3-5 agent 描述
- **模板不自包含** → 前端 Agent 1/2/3 补 `{TARGET_DIR}`/`{STACK_INFO}` 头部并扩充可 grep 的检查清单；后端 Agent 1 的 "same as full-stack Agent 2" 悬空引用全部内联展开（子 agent 零上下文冷启动，引用对它不可见）

## P1 — 质量门与维度补齐

- **模型策略**：4 处 "Opus only / non-negotiable" 改为「最高能力档 + 降级路径」，唯一权威定义在 Core Principles #1，其余处引用（消除跨文件重复）
- **Unified Output Contract**：所有 9 个模板统一附加输出契约 —— 统一 severity rubric（子 agent 此前看不到 SKILL.md 里的分级表，各自发明标准）、`files` 去重键、`evidence_type`/`confidence` 字段（W-11：推断链 >2 步不得高于 medium）、中文输出、25 条上限、`NO_FINDINGS` 显式声明
- **Phase 1.5 Verify**：Critical/High 发现必须经反驳式复核才能进 "Fix Immediately"；被驳回项进「已排除项」附录而非删除；Medium 抽查 ≥30%
- **Phase 0 依赖审计**：确定性命令（cargo audit / npm audit / pip-audit / govulncheck）输出喂给安全 agent 分类；工具缺失必须显式声明「依赖审计降级跳过」
- **测试质量维度**：并入 Agent 4（覆盖缺口、弱化断言、skip 标记、test-stale），不新增 agent
- **并发/异步卫生**：Phase 0 检测到异步运行时才启用（跨 await 持锁、丢 JoinHandle、unbounded channel、N+1、只增不减集合），只报静态可证实项
- **Phase 3 Baseline Diff**：`.audit/` 落盘 + 稳定 finding ID + 已修复/仍存在/新增 三态对比 + false-positives.json 误报沉淀，支撑月度/季度健康检查场景
- **Registry 比对去重**（P2-3 顺带）：Agent 4 的重复布置删除，改为边界声明，Agent 2 为唯一 owner

## 其他

- 补入本地已有但仓库缺失的 `evals/` 目录（expected_output 已同步修复）
- SKILL.md 新增 Evals 段引用，消除 audit_skill_quality 的 support-reference 警告

## 验证

- `python3 scripts/validate_skills.py --check` → 82 skills, 0 errors, 0 warnings
- `python3 scripts/audit_skill_quality.py codebase-audit` → 0 warnings（剩 2 条 info：gotchas / operating-contract 段，属另行增强）
- `validate_skills.py --write` 重新生成 registry，无 diff（description 未变）

## 审计方法

发现来自 5 视角并行分析（一致性/编排/覆盖面/prompt 质量/报告质量），40 条原始发现逐条对照原文反驳式复核，33 条通过后按根因去重为 17 条。完整报告见 issue #56。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

