### PR TITLE
fix: close codebase-audit review followups

### DIFF
--- a/skills/codebase-audit/SKILL.md
+++ b/skills/codebase-audit/SKILL.md
@@ -43,10 +43,10 @@ Detection checklist:
 After stack detection, run the matching dependency audit from the target project root, never from the assistant's incidental current working directory. If the user supplied an explicit target path, use it as `{TARGET_DIR}` before invoking the tool (deterministic, zero LLM cost):
 
 ```
-- Rust → cd {TARGET_DIR} && cargo audit
-- Node → cd {TARGET_DIR} && npm audit
-- Python → cd {TARGET_DIR} && (pip-audit . or pip-audit -r requirements.txt)
-- Go → cd {TARGET_DIR} && govulncheck ./...
+- Rust → cd "{TARGET_DIR}" && cargo audit
+- Node → cd "{TARGET_DIR}" && npm audit
+- Python → cd "{TARGET_DIR}" && if [ -f requirements.txt ]; then pip-audit -r requirements.txt; else pip-audit .; fi
+- Go → cd "{TARGET_DIR}" && govulncheck ./...
 ```
 
 Feed the raw output to the Error Handling & Security agent (frontend-only: to Agent 2) for classification: Critical = RCE-grade CVE with PoC on a reachable path; High = known vuln on a reachable path. If the tool is unavailable, the report MUST state "依赖审计降级跳过" — never omit silently.

--- a/skills/codebase-audit/SKILL.md
+++ b/skills/codebase-audit/SKILL.md
@@ -40,11 +40,13 @@ Detection checklist:
   Data Integrity agent (see agent-prompts.md)
 ```
 
-After stack detection, run the matching dependency audit (deterministic, zero LLM cost):
+After stack detection, run the matching dependency audit from the target project root, never from the assistant's incidental current working directory. If the user supplied an explicit target path, use it as `{TARGET_DIR}` before invoking the tool (deterministic, zero LLM cost):
 
 ```
-- Rust → cargo audit       - Node → npm audit
-- Python → pip-audit       - Go → govulncheck ./...
+- Rust → cd {TARGET_DIR} && cargo audit
+- Node → cd {TARGET_DIR} && npm audit
+- Python → cd {TARGET_DIR} && (pip-audit . or pip-audit -r requirements.txt)
+- Go → cd {TARGET_DIR} && govulncheck ./...
 ```
 
 Feed the raw output to the Error Handling & Security agent (frontend-only: to Agent 2) for classification: Critical = RCE-grade CVE with PoC on a reachable path; High = known vuln on a reachable path. If the tool is unavailable, the report MUST state "依赖审计降级跳过" — never omit silently.
@@ -133,6 +135,7 @@ After verification completes, compile findings into a single report.
 | Critical | N | ... |
 | High | N | ... |
 | Medium | N | ... |
+| Low | N | ... |
 
 ## Critical (Fix Immediately)
 | # | Problem | Agent | Impact | evidence_type | confidence | 验证状态 |
@@ -146,6 +149,9 @@ For each: file:line, code snippet, risk description (推断需标注置信度), 
 ## Medium (Plan to Fix)
 [Same structure]
 
+## Low (Informational)
+[Same structure; include only if Low findings exist]
+
 ## 已排除项 (Refuted in Phase 1.5)
 | # | Original claim | Refutation reason |
 |---|----------------|-------------------|
@@ -156,7 +162,7 @@ For each: file:line, code snippet, risk description (推断需标注置信度), 
 | Phase 0 (urgent) | Critical fixes | ~N files |
 | Phase 1 (this week) | High priority | ~N files |
 | Phase 2 (next week) | Medium priority | ~N files |
-| Phase 3 (ongoing) | Architecture | ~N files |
+| Phase 3 (ongoing) | Low / Architecture | ~N files |
 
 Est. Files = 该级别所有发现 files 字段去重并集大小；若修复涉及发现位置之外的文件，可追加估算但必须标注「推断，置信度低」。
 ```

--- a/skills/codebase-audit/SKILL.md
+++ b/skills/codebase-audit/SKILL.md
@@ -45,7 +45,7 @@ After stack detection, run the matching dependency audit from the target project
 ```
 - Rust → cd "{TARGET_DIR}" && cargo audit
 - Node → cd "{TARGET_DIR}" && npm audit
-- Python → cd "{TARGET_DIR}" && if [ -f requirements.txt ]; then pip-audit -r requirements.txt; else pip-audit .; fi
+- Python → cd "{TARGET_DIR}" && if [ -f pyproject.toml ] || [ -f setup.py ]; then pip-audit .; [ -f requirements.txt ] && pip-audit -r requirements.txt; elif [ -f requirements.txt ]; then pip-audit -r requirements.txt; else pip-audit .; fi
 - Go → cd "{TARGET_DIR}" && govulncheck ./...
 ```
 

--- a/skills/codebase-audit/evals/evals.json
+++ b/skills/codebase-audit/evals/evals.json
@@ -3,13 +3,13 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "帮我全面审查一下 /Users/lifcc/Desktop/code/work/mutil-om 这个项目的设计问题",
-      "expected_output": "按检测到的技术栈启动对应数量的并行 agent（全栈 5 / 后端 4 / 前端 3），agent 类型全部来自真实注册表；Critical/High 发现经 Phase 1.5 复核后输出 Critical/High/Medium 分级统一报告（含 evidence_type/confidence/验证状态列）+ 修复路线图",
+      "prompt": "帮我全面审查一下当前仓库这个项目的设计问题",
+      "expected_output": "按检测到的技术栈启动对应数量的并行 agent（全栈 5 / 后端 4 / 前端 3），agent 类型全部来自真实注册表；Critical/High 发现经 Phase 1.5 复核后输出 Critical/High/Medium/Low 分级统一报告（含 evidence_type/confidence/验证状态列）+ 修复路线图",
       "files": []
     },
     {
       "id": 2,
-      "prompt": "/codebase-audit /Users/lifcc/Desktop/code/work/mutil-om",
+      "prompt": "/codebase-audit .",
       "expected_output": "同 eval 1，通过 slash command 触发；agent 数量与检测到的栈类型匹配",
       "files": []
     },


### PR DESCRIPTION
Follow-up for PR #57 review threads that arrived after merge.

## Summary
- run deterministic dependency audits from `{TARGET_DIR}` instead of the assistant cwd
- add an explicit Low findings destination in the Phase 2 report template and roadmap
- make codebase-audit eval prompts self-contained by removing private absolute paths

## Verification
- python3 scripts/validate_skills.py --check
- python3 scripts/audit_skill_quality.py codebase-audit
- pytest