### PR TITLE
Harden skill path handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,13 @@ validate_target() {
     esac
 }
 
+validate_skill_name() {
+    local skill_name="$1"
+    if [[ ! "$skill_name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+        error "Invalid skill name: $skill_name (expected kebab-case lowercase letters, digits, and hyphens)"
+    fi
+}
+
 # Create target directories
 setup_directories() {
     info "Setting up target directories for: $TARGET"
@@ -302,6 +309,7 @@ install_skills_to_dir() {
 
     for skill in "${SKILLS[@]}"; do
         skill=$(echo "$skill" | xargs) # trim whitespace
+        validate_skill_name "$skill"
 
         # Check if directory-based skill
         if [ -f "$INSTALL_DIR/skills/$skill/SKILL.md" ]; then

--- a/scripts/skill_path_safety.py
+++ b/scripts/skill_path_safety.py
@@ -1,0 +1,27 @@
+"""Repo-level wrapper for skill-creator path safety helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+HELPER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "skill-creator"
+    / "scripts"
+    / "path_safety.py"
+)
+
+spec = importlib.util.spec_from_file_location("spellbook_skill_creator_path_safety", HELPER_PATH)
+if spec is None or spec.loader is None:
+    raise ImportError(f"Could not load path safety helpers from {HELPER_PATH}")
+_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(_module)
+
+UnsafePathError = _module.UnsafePathError
+is_relative_to = _module.is_relative_to
+safe_archive_name = _module.safe_archive_name
+safe_kebab_name = _module.safe_kebab_name
+safe_output_path = _module.safe_output_path

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -10,6 +10,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from skill_path_safety import UnsafePathError, safe_kebab_name, safe_output_path
+
 try:
     import yaml
 except ImportError:  # pragma: no cover - exercised only on minimal user systems.
@@ -415,6 +417,13 @@ def validate_entries(entries: list[SkillEntry]) -> list[str]:
     seen_frontmatter_names: dict[str, str] = {}
 
     for entry in entries:
+        try:
+            safe_kebab_name(entry.install_name, kind="install name")
+            safe_output_path(ROOT, entry.path, kind="skill registry path")
+        except UnsafePathError as exc:
+            messages.append(error(f"{entry.path} has unsafe registry path or install name: {exc}"))
+            continue
+
         path = ROOT / entry.path
         frontmatter, parse_messages = parse_frontmatter(path)
         messages.extend(parse_messages)
@@ -681,7 +690,9 @@ def main() -> int:
     entries = discover_skills()
     messages = validate_entries(entries)
 
-    if args.write:
+    validation_errors = [message for message in messages if message.startswith("ERROR:")]
+
+    if args.write and not validation_errors:
         write_generated_files(entries)
 
     if args.check:

--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 QUICK_VALIDATE_PATH = SCRIPT_DIR / "quick_validate.py"
+SAFE_PATHS_PATH = SCRIPT_DIR / "path_safety.py"
 
 
 def load_validate_skill():
@@ -34,21 +35,27 @@ def load_validate_skill():
 
 validate_skill = load_validate_skill()
 
+
+def load_safe_paths():
+    spec = importlib.util.spec_from_file_location(
+        "skill_creator_safe_paths",
+        SAFE_PATHS_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load path safety helpers from {SAFE_PATHS_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+safe_paths = load_safe_paths()
+
 # Patterns to exclude when packaging skills.
 EXCLUDE_DIRS = {"__pycache__", "node_modules"}
 EXCLUDE_GLOBS = {"*.pyc"}
 EXCLUDE_FILES = {".DS_Store"}
 # Directories excluded only at the skill root (not when nested deeper).
 ROOT_EXCLUDE_DIRS = {"evals"}
-
-
-def is_relative_to(path: Path, directory: Path) -> bool:
-    """Return whether path is contained by directory after resolution."""
-    try:
-        path.relative_to(directory)
-        return True
-    except ValueError:
-        return False
 
 
 def should_exclude(rel_path: Path) -> bool:
@@ -69,9 +76,11 @@ def should_exclude(rel_path: Path) -> bool:
 def collect_package_entries(skill_path: Path):
     """Collect package entries after rejecting unsafe filesystem paths."""
     entries = []
+    skill_root_name = safe_paths.safe_kebab_name(skill_path.name, kind="skill directory name")
 
     for file_path in skill_path.rglob('*'):
-        arcname = file_path.relative_to(skill_path.parent)
+        rel_arcname = file_path.relative_to(skill_path.parent)
+        arcname = Path(safe_paths.safe_archive_name(skill_root_name, *rel_arcname.parts[1:]))
         if should_exclude(arcname):
             continue
         if file_path.is_symlink():
@@ -80,7 +89,7 @@ def collect_package_entries(skill_path: Path):
             continue
 
         resolved_file = file_path.resolve(strict=True)
-        if not is_relative_to(resolved_file, skill_path):
+        if not safe_paths.is_relative_to(resolved_file, skill_path):
             raise ValueError(f"Refusing to package file outside skill folder: {arcname}")
         entries.append((file_path, arcname))
 
@@ -124,18 +133,17 @@ def package_skill(skill_path, output_dir=None):
         return None
     print(f"✅ {message}\n")
 
-    # Determine output location
-    skill_name = skill_path.name
-    if output_dir:
-        output_path = Path(output_dir).resolve()
-        output_path.mkdir(parents=True, exist_ok=True)
-    else:
-        output_path = Path.cwd()
-
-    skill_filename = output_path / f"{skill_name}.skill"
-
     # Create the .skill file (zip format)
     try:
+        # Determine output location only after validating the package root name.
+        skill_name = safe_paths.safe_kebab_name(skill_path.name, kind="skill directory name")
+        if output_dir:
+            output_path = Path(output_dir).resolve()
+            output_path.mkdir(parents=True, exist_ok=True)
+        else:
+            output_path = Path.cwd()
+
+        skill_filename = safe_paths.safe_output_path(output_path, f"{skill_name}.skill")
         package_entries = collect_package_entries(skill_path)
         with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
             for file_path, arcname in package_entries:

--- a/skills/skill-creator/scripts/path_safety.py
+++ b/skills/skill-creator/scripts/path_safety.py
@@ -1,0 +1,78 @@
+"""Path safety helpers for skill packaging and generation scripts."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+
+class UnsafePathError(ValueError):
+    """Raised when an untrusted path or name would escape its container."""
+
+
+SAFE_KEBAB_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def is_relative_to(path: Path, directory: Path) -> bool:
+    """Return whether ``path`` is contained by ``directory``."""
+    try:
+        path.relative_to(directory)
+        return True
+    except ValueError:
+        return False
+
+
+def safe_kebab_name(value: str, *, kind: str = "name") -> str:
+    """Validate a single untrusted kebab-case path component."""
+    if not value:
+        raise UnsafePathError(f"{kind} must not be empty")
+    if value in {".", ".."}:
+        raise UnsafePathError(f"{kind} must not be {value!r}")
+    if "/" in value or "\\" in value:
+        raise UnsafePathError(f"{kind} must not contain path separators: {value!r}")
+    if not SAFE_KEBAB_RE.fullmatch(value):
+        raise UnsafePathError(
+            f"{kind} must be kebab-case lowercase letters, digits, and hyphens: {value!r}"
+        )
+    if len(value) > 64:
+        raise UnsafePathError(f"{kind} is too long ({len(value)} characters); maximum is 64")
+    return value
+
+
+def _reject_absolute_or_drive(path: Path | str, *, kind: str) -> None:
+    raw = str(path)
+    if Path(raw).is_absolute() or PureWindowsPath(raw).is_absolute() or PureWindowsPath(raw).drive:
+        raise UnsafePathError(f"{kind} must be relative: {raw!r}")
+
+
+def safe_output_path(base: Path, candidate: Path | str, *, kind: str = "output") -> Path:
+    """Join ``candidate`` under ``base`` and reject traversal or absolute paths."""
+    _reject_absolute_or_drive(candidate, kind=kind)
+    candidate_path = Path(candidate)
+    if any(part in {"", ".", ".."} for part in candidate_path.parts):
+        raise UnsafePathError(f"{kind} contains unsafe component: {candidate!r}")
+    if any("\\" in part for part in candidate_path.parts):
+        raise UnsafePathError(f"{kind} contains unsafe separator: {candidate!r}")
+
+    base_path = Path(base).expanduser().resolve()
+    output = Path(os.path.normpath(base_path / candidate_path))
+    if not is_relative_to(output, base_path):
+        raise UnsafePathError(f"{kind} escapes destination directory: {output}")
+    return output
+
+
+def safe_archive_name(*parts: Path | str) -> str:
+    """Build a portable relative archive member name."""
+    raw_parts: list[str] = []
+    for part in parts:
+        _reject_absolute_or_drive(part, kind="archive name")
+        raw_parts.extend(PurePosixPath(str(part).replace("\\", "/")).parts)
+
+    if not raw_parts:
+        raise UnsafePathError("archive name must not be empty")
+    if any(part in {"", ".", ".."} for part in raw_parts):
+        raise UnsafePathError(f"archive name contains unsafe component: {'/'.join(raw_parts)!r}")
+    if any("\\" in part for part in raw_parts):
+        raise UnsafePathError(f"archive name contains unsafe separator: {'/'.join(raw_parts)!r}")
+    return PurePosixPath(*raw_parts).as_posix()

--- a/skills/skill-creator/scripts/run_eval.py
+++ b/skills/skill-creator/scripts/run_eval.py
@@ -6,6 +6,7 @@ for a set of queries. Outputs results as JSON.
 """
 
 import argparse
+import importlib.util
 import json
 import os
 import select
@@ -17,6 +18,24 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 from scripts.utils import parse_skill_md
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PATH_SAFETY_PATH = SCRIPT_DIR / "path_safety.py"
+
+
+def load_path_safety():
+    spec = importlib.util.spec_from_file_location(
+        "spellbook_path_safety",
+        PATH_SAFETY_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load path safety helpers from {PATH_SAFETY_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+path_safety = load_path_safety()
 
 
 def find_project_root() -> Path:
@@ -49,9 +68,14 @@ def run_single_query(
     full assistant message, which only arrives after tool execution.
     """
     unique_id = uuid.uuid4().hex[:8]
-    clean_name = f"{skill_name}-skill-{unique_id}"
+    safe_skill_name = path_safety.safe_kebab_name(skill_name, kind="skill name")
+    clean_name = f"{safe_skill_name}-skill-{unique_id}"
     project_commands_dir = Path(project_root) / ".claude" / "commands"
-    command_file = project_commands_dir / f"{clean_name}.md"
+    command_file = path_safety.safe_output_path(
+        project_commands_dir,
+        f"{clean_name}.md",
+        kind="command file",
+    )
 
     try:
         project_commands_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_install_prune.py
+++ b/tests/test_install_prune.py
@@ -82,6 +82,36 @@ class InstallPruneTests(unittest.TestCase):
             self.assertTrue(spellbook_named_user_link.is_symlink())
             self.assertTrue(arsenal_named_user_link.is_symlink())
 
+    def test_selected_skill_name_cannot_escape_target_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            source_skills = home / ".spellbook" / "skills"
+            target_skills = home / ".claude" / "skills"
+            source_skills.mkdir(parents=True)
+            target_skills.mkdir(parents=True)
+
+            env = os.environ.copy()
+            env["HOME"] = str(home)
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    (
+                        "source ./install.sh; "
+                        'install_skills_to_dir "$CLAUDE_SKILLS_DIR" "Claude Code" "../outside"'
+                    ),
+                ],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Invalid skill name", result.stdout + result.stderr)
+            self.assertFalse((home / ".claude" / "outside").exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_package_skill.py
+++ b/tests/test_package_skill.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGE_SKILL_SCRIPT = (
     REPO_ROOT / "skills" / "skill-creator" / "scripts" / "package_skill.py"
 )
+SAFE_PATHS_SCRIPT = REPO_ROOT / "scripts" / "skill_path_safety.py"
 
 
 def load_package_skill():
@@ -26,6 +27,19 @@ def load_package_skill():
 
 
 package_skill = load_package_skill()
+
+
+def load_safe_paths():
+    spec = importlib.util.spec_from_file_location(
+        "skill_creator_safe_paths_test",
+        SAFE_PATHS_SCRIPT,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+safe_paths = load_safe_paths()
 
 
 class PackageSkillTests(unittest.TestCase):
@@ -81,6 +95,92 @@ class PackageSkillTests(unittest.TestCase):
             self.assertIsNone(archive_path)
             self.assertIn("Symlinks are not allowed", stdout.getvalue())
             self.assertFalse((output_dir / "safe-skill.skill").exists())
+
+    def test_rejects_unsafe_skill_directory_name(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            skill_path = root / "unsafe name"
+            skill_path.mkdir()
+            (skill_path / "SKILL.md").write_text(
+                "---\n"
+                "name: safe-skill\n"
+                "description: A safe skill in an unsafe directory name.\n"
+                "---\n\n"
+                "# Safe Skill\n",
+                encoding="utf-8",
+            )
+            output_dir = root / "dist"
+
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                archive_path = package_skill(skill_path, output_dir)
+
+            self.assertIsNone(archive_path)
+            self.assertIn("skill directory name", stdout.getvalue())
+            self.assertFalse(output_dir.exists())
+
+    def test_rejects_backslash_skill_directory_name(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            skill_path = root / "unsafe\\name"
+            try:
+                skill_path.mkdir()
+            except OSError as exc:
+                self.skipTest(f"backslash filename is not available: {exc}")
+            (skill_path / "SKILL.md").write_text(
+                "---\n"
+                "name: safe-skill\n"
+                "description: A safe skill in an unsafe directory name.\n"
+                "---\n\n"
+                "# Safe Skill\n",
+                encoding="utf-8",
+            )
+            output_dir = root / "dist"
+
+            with redirect_stdout(io.StringIO()):
+                archive_path = package_skill(skill_path, output_dir)
+
+            self.assertIsNone(archive_path)
+            self.assertFalse(output_dir.exists())
+
+    def test_safe_output_path_rejects_escape_payloads(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            payloads = [
+                "../pwned.skill",
+                "../../etc/passwd.skill",
+                "/absolute/evil.skill",
+                "subdir/../../escape.skill",
+                "evil\\name.skill",
+            ]
+
+            for payload in payloads:
+                with self.subTest(payload=payload):
+                    with self.assertRaises(ValueError):
+                        safe_paths.safe_output_path(root, payload)
+                    self.assertFalse((root.parent / "pwned.skill").exists())
+
+    def test_safe_zip_arcname_rejects_traversal_payloads(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            skill_parent = root / "skills"
+            skill_parent.mkdir()
+            file_path = skill_parent / "safe-skill" / "SKILL.md"
+            file_path.parent.mkdir()
+            file_path.write_text("ok", encoding="utf-8")
+
+            self.assertEqual(
+                safe_paths.safe_archive_name(*file_path.relative_to(skill_parent).parts),
+                "safe-skill/SKILL.md",
+            )
+            for root_name in ["../pwned", "..\\pwned"]:
+                with self.subTest(root_name=root_name):
+                    with self.assertRaises(ValueError):
+                        safe_paths.safe_archive_name(root_name, "SKILL.md")
+            for root_name in ["unsafe name", "unsafe\\name"]:
+                with self.subTest(root_name=root_name):
+                    with self.assertRaises(ValueError):
+                        safe_paths.safe_kebab_name(root_name, kind="skill directory name")
 
     def test_loads_sibling_validator_when_top_level_name_is_taken(self):
         fake_validator = types.ModuleType("quick_validate")

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -1,0 +1,72 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATH_SAFETY_SCRIPT = ROOT / "scripts" / "skill_path_safety.py"
+
+
+def load_path_safety():
+    spec = importlib.util.spec_from_file_location("spellbook_path_safety_test", PATH_SAFETY_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+path_safety = load_path_safety()
+
+
+class PathSafetyTests(unittest.TestCase):
+    def test_safe_kebab_name_rejects_unsafe_names(self):
+        for payload in ["", ".", "..", "../pwned", "unsafe name", "safe\\..\\evil", "UPPER"]:
+            with self.subTest(payload=payload):
+                with self.assertRaises(path_safety.UnsafePathError):
+                    path_safety.safe_kebab_name(payload)
+
+    def test_safe_output_path_rejects_escape_payloads(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            for payload in [
+                "../pwned",
+                "../../etc/passwd",
+                "/absolute/evil",
+                "subdir/../../escape",
+                "..\\pwned",
+                "safe\\..\\evil",
+            ]:
+                with self.subTest(payload=payload):
+                    with self.assertRaises(path_safety.UnsafePathError):
+                        path_safety.safe_output_path(root, payload)
+
+    def test_safe_output_path_allows_contained_relative_path(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.assertEqual(
+                path_safety.safe_output_path(root, "dist/safe-skill.skill"),
+                root.resolve() / "dist" / "safe-skill.skill",
+            )
+
+    def test_safe_archive_name_rejects_traversal_payloads(self):
+        for payload in [
+            ("../pwned",),
+            ("../../etc/passwd",),
+            ("/absolute/evil",),
+            ("subdir/../../escape",),
+            ("..\\pwned",),
+            ("safe\\..\\evil",),
+        ]:
+            with self.subTest(payload=payload):
+                with self.assertRaises(path_safety.UnsafePathError):
+                    path_safety.safe_archive_name(*payload)
+
+    def test_safe_archive_name_uses_posix_separators(self):
+        self.assertEqual(
+            path_safety.safe_archive_name("safe-skill", "references", "guide.md"),
+            "safe-skill/references/guide.md",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_eval_path_safety.py
+++ b/tests/test_run_eval_path_safety.py
@@ -1,0 +1,57 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_CREATOR_ROOT = ROOT / "skills" / "skill-creator"
+RUN_EVAL_SCRIPT = SKILL_CREATOR_ROOT / "scripts" / "run_eval.py"
+
+
+def load_run_eval():
+    sys.path.insert(0, str(SKILL_CREATOR_ROOT))
+    previous_scripts = sys.modules.pop("scripts", None)
+    package = types.ModuleType("scripts")
+    package.__path__ = [str(SKILL_CREATOR_ROOT / "scripts")]
+    sys.modules["scripts"] = package
+    try:
+        spec = importlib.util.spec_from_file_location("skill_creator_run_eval_test", RUN_EVAL_SCRIPT)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SKILL_CREATOR_ROOT))
+        sys.modules.pop("skill_creator_run_eval_test", None)
+        sys.modules.pop("scripts", None)
+        if previous_scripts is not None:
+            sys.modules["scripts"] = previous_scripts
+
+
+run_eval = load_run_eval()
+
+
+class RunEvalPathSafetyTests(unittest.TestCase):
+    def test_run_single_query_rejects_unsafe_skill_name_before_writing_command(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / ".claude" / "commands").mkdir(parents=True)
+
+            with self.assertRaises(ValueError):
+                run_eval.run_single_query(
+                    query="use the skill",
+                    skill_name="../../pwned",
+                    skill_description="Unsafe name should be rejected.",
+                    timeout=1,
+                    project_root=str(root),
+                )
+
+            self.assertEqual(list((root / ".claude" / "commands").iterdir()), [])
+            self.assertFalse(any(path.name.startswith("pwned") for path in root.iterdir()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_skills_path_safety.py
+++ b/tests/test_validate_skills_path_safety.py
@@ -1,0 +1,42 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATE_SCRIPT = ROOT / "scripts" / "validate_skills.py"
+
+
+def load_validate_skills():
+    sys.path.insert(0, str(ROOT / "scripts"))
+    try:
+        spec = importlib.util.spec_from_file_location("validate_skills_path_safety_test", VALIDATE_SCRIPT)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(ROOT / "scripts"))
+        sys.modules.pop("validate_skills_path_safety_test", None)
+
+
+validate_skills = load_validate_skills()
+
+
+class ValidateSkillsPathSafetyTests(unittest.TestCase):
+    def test_validate_entries_rejects_unsafe_install_name_before_reading_path(self):
+        entry = validate_skills.SkillEntry(
+            install_name="../outside",
+            path="../outside/SKILL.md",
+            format="directory",
+            frontmatter={},
+        )
+
+        messages = validate_skills.validate_entries([entry])
+
+        self.assertTrue(any("unsafe registry path or install name" in message for message in messages))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #71.

This hardens skill packaging and generation paths against traversal and unsafe output names without changing merge behavior.

Changes:
- add reusable path safety helpers for kebab-case skill names, output paths, and zip archive member names
- keep `skill-creator` self-contained by shipping its helper inside `skills/skill-creator/scripts/`
- validate selected skill names in `install.sh` before symlink creation
- reject unsafe registry install names and paths in `validate_skills.py`
- make `validate_skills.py --write` skip generated-file writes when validation has errors
- validate `package_skill.py` archive/output paths and reject unsafe skill directory names
- validate `run_eval.py` command file names before writing `.claude/commands/*.md`
- add regression tests for install traversal, packaging traversal, eval command names, and registry validation

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -q`
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/validate_skills.py --check`
- `bash -n install.sh && git diff --check`

## Notes

This PR intentionally does not implement #70 validation policy changes or #72 layering design. Those stay as separate queue items/PRs.