### PR TITLE
[codex] Clarify threads reviewer verification budget

### DIFF
--- a/skills/threads/SKILL.md
+++ b/skills/threads/SKILL.md
@@ -227,6 +227,7 @@ lanes:
   writable_files:
   forbidden_files:
   exclusive_verification:
+  verification_scope: inspection_only | targeted | full_local | ci_only
   expected_output:
   verification:
 ```
@@ -244,11 +245,29 @@ Rules:
 - For GitHub queues, treat comments and review threads as first-class remote state; open PR/issue lists alone are not enough.
 - Default WIP limit: at most 3 planning/research lanes, 2 concurrent writable implementation lanes, and 2 reviewers per PR unless the user explicitly grants a larger budget.
 
+## Verification Budget
+
+Use `verification_scope` to keep review evidence useful without duplicating expensive full-suite work:
+
+- `inspection_only`: read-only diff/code inspection. Cheap static checks such as `git diff --check` are allowed when they are relevant.
+- `targeted`: focused tests or linters for touched behavior only.
+- `full_local`: one owner runs the project-wide local suite for the tranche, usually the root orchestrator, `verification_owner`, or a `merge_reviewer`.
+- `ci_only`: fresh CI tied to the current head SHA is the full-suite truth source.
+
+Rules:
+
+- Assign at most one full-suite owner per tranche. If fresh CI is the full-suite truth source, do not also ask every reviewer to repeat the local full suite.
+- Reviewer lanes default to `inspection_only` or `targeted`. They must not run full project test suites unless the lane map explicitly names them as `verification_owner` or `merge_reviewer`.
+- Targeted reviewer checks should be command-valid for the language/tool. For Cargo, pass one test filter per `cargo test` command, or use a broader module/path filter; do not pass several unrelated test names as positional filters in one command.
+- If a targeted check touches shared state, global caches, local daemons, or repo-level generated state, move it to the serialized `verification_owner` lane.
+
 ## Dispatch
 
 Use native subagents when available. If the multi-agent tool is not loaded, search for it using tool discovery. Do not use shell/tmux/OMX orchestration unless explicitly requested.
 
 When `multi_agent_v1` tools are available, use `spawn_agent` for bounded sidecar lanes, `wait_agent` only when the next critical-path step needs that result, and `close_agent` after collecting completed output. Keep immediate blockers in the main thread.
+
+Close completed subagents as soon as their evidence has been collected. For long issue/PR queues, finish a bounded tranche, record the ledger and resume query, and consider starting a fresh parent thread instead of carrying oversized context forward.
 
 Use these lane types:
 

--- a/skills/threads/references/prompt-patterns.md
+++ b/skills/threads/references/prompt-patterns.md
@@ -29,7 +29,12 @@ Use these templates as raw material. Fill concrete repo paths, PR numbers, issue
 - 不要把 Codex threads 路由到 OMX/tmux。
 - 每个实现 lane 必须有 disjoint writable_files。
 - shared-state verification（如 .git/hooks、HOME、global cache、daemon）必须由 verification_owner 串行执行，除非显式隔离。
+- lane_map 必须写 `verification_scope`：`inspection_only` / `targeted` / `full_local` / `ci_only`。
+- reviewer lane 默认只读 diff/code inspection，可跑 `git diff --check` 或便宜静态检查；只在需要 review confidence 时跑 touched behavior 的 targeted tests。
+- reviewer lane 默认不跑 full project test suite；full suite 只能由一个明确 owner 跑，通常是 root orchestrator、verification_owner、merge_reviewer，或由当前 head SHA 的 fresh CI 提供。
+- Cargo 测试过滤要合法：每个 `cargo test` 命令只传一个 filter，或使用 module/path 级 filter；不要把多个无关 test name 当多个 positional filters 传给同一条命令。
 - review lane 只读。
+- 完成的 subagent 要及时 close；长 issue/PR 队列完成一个 bounded tranche 后，记录 ledger/resume query，并考虑开新 parent thread 降低上下文负担。
 - 高上下文文件 AGENTS.md/CLAUDE.md/settings/hooks 默认禁止修改。
 - 每个 PR merge 前必须有独立 thread review。
 - merge 前必须 truth_level=A，并用 thread-aware GitHub 数据检查 reviewThreads.isResolved；open PR/issue 为空不等于评论闭环完成。
@@ -103,7 +108,7 @@ Target: {{issue_or_pr_or_queue}}
 8. 未完成/风险
 9. 推荐处理动作和理由
 10. 可并行 worktree 拆分
-11. 每个 lane 的 writable_files、forbidden_files、exclusive_verification
+11. 每个 lane 的 writable_files、forbidden_files、exclusive_verification、verification_scope
 12. 必须运行的验证命令
 13. 不应在本轮强做的范围
 14. 建议的 failure_codes（如 stale_remote_state、duplicate_work_missed、missing_intent_contract）
@@ -134,6 +139,8 @@ Target: {{issue_or_pr_or_queue}}
 
 验证：
 {{verification_commands}}
+verification_scope:
+{{verification_scope}}
 
 Remote refresh:
 - 在 push 前运行 git fetch --prune origin 并比较 origin/main 与 lane base_ref。
@@ -156,6 +163,13 @@ Remote refresh:
 ```text
 请对 {{target_pr_or_worktree}} 做只读 code review，不要修改文件，不要提交，不要 merge。
 目标：{{issue_or_pr_goal}}
+
+验证范围：
+- 默认 `verification_scope=inspection_only`：做 diff/code inspection。
+- 可运行便宜静态检查，如 `git diff --check`，或与 touched behavior 直接相关的 targeted tests。
+- 不要运行 full project test suite，除非 lane_map 明确指定你是 `verification_owner` 或 `merge_reviewer`。
+- 如果需要 Cargo targeted tests，每条 `cargo test` 命令只传一个 test filter，或使用 module/path 级 filter；不要把多个无关 test name 放进同一条命令。
+- 报告未运行的 full-suite 验证，并说明由谁负责：root orchestrator、verification_owner、merge_reviewer，或 fresh CI。
 
 重点检查：
 - security and injection risks
@@ -265,6 +279,8 @@ No findings; safe to merge.
 ```text
 开最多 2 个只读 reviewer threads 审查 {{target_pr_or_diff}}。
 不要修改文件，不要提交，不要 merge。
+默认 verification_scope=inspection_only；只运行便宜静态检查或 touched behavior targeted tests。
+不要运行 full project test suite，除非 lane_map 明确指定 reviewer 是 verification_owner 或 merge_reviewer。
 
 输出 findings first；如果没有 blocking issue，写 No findings; safe to proceed。
 说明未验证项和残余风险。

--- a/skills/threads/references/run-log.md
+++ b/skills/threads/references/run-log.md
@@ -139,6 +139,7 @@ Recommended fields:
       "worktree": "/tmp/repo-worker-1",
       "writable_files": ["src/example.rs"],
       "files_changed": ["src/example.rs"],
+      "verification_scope": "targeted",
       "verification": ["cargo test example"],
       "result": "passed|blocked|failed"
     }


### PR DESCRIPTION
## Summary

- Add `verification_scope` to threads lane maps so each lane can declare inspection-only, targeted, full-local, or CI-backed verification.
- Document that reviewer lanes default to read-only inspection or targeted checks and must not run full project suites unless they own verification or are merge reviewers.
- Add Cargo test-filter hygiene and bounded-tranche context cleanup guidance.

## Verification

- `git diff --check`
- `python3 scripts/validate_skills.py --check` (82 skills, 0 errors, 0 warnings)
- `python3 -m pytest` (46 passed)
- `python3 scripts/audit_skill_quality.py` (0 warnings; INFO-only existing notes)
- Independent read-only reviewer lane: No findings; safe to proceed.

Fixes #79