### PR TITLE
[codex] Tighten threads native dispatch evidence

### DIFF
--- a/skills/threads/SKILL.md
+++ b/skills/threads/SKILL.md
@@ -35,7 +35,7 @@ For any implementation mode, start with a lane map before spawning workers. For 
 
 ## Explicit Thread Dispatch Gate
 
-When the user explicitly asks for threads, subagents, "开几个子 agent", or a GitHub issue/PR queue that the skill classifies as `execute_direct`, `review_only`, or `research_spec`, native dispatch is required whenever native subagent tools are available.
+When the user explicitly asks for threads, subagents, "开几个子 agent", or a GitHub issue/PR queue that the skill classifies as `plan_only`, `execute_direct`, `review_only`, or `research_spec`, native dispatch is required whenever native subagent tools are available.
 
 Record this gate before implementation, review, or merge work:
 
@@ -44,11 +44,14 @@ thread_dispatch_gate:
 - explicit_thread_request: yes | no
 - native_subagents: available | unavailable
 - spawn_requirement: required | optional | unavailable
+- fallback_mode: single_agent | prompt_pack_only | none
 - planned_native_threads:
   - id:
     role:
     target:
     write_scope: read_only | disjoint_writable | none
+    spawn_status: planned | spawned | skipped
+    no_spawn_reason:
 - native_thread_evidence:
     user_requested_native_threads: yes | no
     spawned_agents:
@@ -66,6 +69,7 @@ Rules:
 
 - If `explicit_thread_request: yes`, `native_subagents: available`, and `spawn_requirement: required`, spawn at least one bounded native subagent before claiming the run is using threads.
 - `native_subagents: available` plus `fallback_mode: none` is valid only when `native_thread_evidence.spawned_agents` contains at least one real agent/thread ID.
+- Every `planned_native_threads` lane must have a matching `native_thread_evidence.spawned_agents[].lane_id` or a lane-level `no_spawn_reason`; spawning one native thread does not justify running the remaining planned lanes serially.
 - A main-thread lane is a coordinator lane, not a native thread. Do not count the coordinator as `native_thread_evidence.spawned_agents`.
 - If no native thread is spawned, set `fallback_mode: single_agent` and write `no_spawn_reason` before editing files, commenting on GitHub, or merging. Valid reasons are narrow: task is tiny and truly sequential, all possible writable lanes overlap, native tools are unavailable, or the user explicitly asks not to spawn.
 - For GitHub PR merge work, at least one read-only reviewer or merge-reviewer native thread is required when native subagents are available. A self-review by the coordinator does not satisfy the independent review lane.

--- a/skills/threads/SKILL.md
+++ b/skills/threads/SKILL.md
@@ -29,9 +29,47 @@ Choose one mode:
 - **research_spec**: split exploration by angle, then synthesize docs/spec/issues.
 - **clarify_first**: ask only when repo, target queue, permission, or done-when is missing.
 
-Prefer `single_agent` for one-file fixes, simple questions, or tasks where the next step depends on one immediate result. Use parallel lanes only when the work can be split by independent targets or disjoint writable files.
+Use `single_agent` only for one-file fixes, simple questions, or tasks where the next step depends on one immediate result. If the user explicitly asks for threads, subagents, or a GitHub issue/PR queue and native subagents are available, do not silently choose `single_agent`; record a concrete `no_spawn_reason` before implementation work begins.
 
 For any implementation mode, start with a lane map before spawning workers. For GitHub issue/PR queues, complete the Capability Gate and Queue Gate first; do not create worker lanes until `capability_gate`, `queue_gate`, `queue_ledger`, and `issue_to_pr_map` are written.
+
+## Explicit Thread Dispatch Gate
+
+When the user explicitly asks for threads, subagents, "开几个子 agent", or a GitHub issue/PR queue that the skill classifies as `execute_direct`, `review_only`, or `research_spec`, native dispatch is required whenever native subagent tools are available.
+
+Record this gate before implementation, review, or merge work:
+
+```text
+thread_dispatch_gate:
+- explicit_thread_request: yes | no
+- native_subagents: available | unavailable
+- spawn_requirement: required | optional | unavailable
+- planned_native_threads:
+  - id:
+    role:
+    target:
+    write_scope: read_only | disjoint_writable | none
+- native_thread_evidence:
+    user_requested_native_threads: yes | no
+    spawned_agents:
+      - lane_id:
+        spawn_tool:
+        agent_id_or_thread_id:
+        wait_evidence:
+        close_evidence:
+        result_collected: yes | no
+    fallback_reason:
+- no_spawn_reason:
+```
+
+Rules:
+
+- If `explicit_thread_request: yes`, `native_subagents: available`, and `spawn_requirement: required`, spawn at least one bounded native subagent before claiming the run is using threads.
+- `native_subagents: available` plus `fallback_mode: none` is valid only when `native_thread_evidence.spawned_agents` contains at least one real agent/thread ID.
+- A main-thread lane is a coordinator lane, not a native thread. Do not count the coordinator as `native_thread_evidence.spawned_agents`.
+- If no native thread is spawned, set `fallback_mode: single_agent` and write `no_spawn_reason` before editing files, commenting on GitHub, or merging. Valid reasons are narrow: task is tiny and truly sequential, all possible writable lanes overlap, native tools are unavailable, or the user explicitly asks not to spawn.
+- For GitHub PR merge work, at least one read-only reviewer or merge-reviewer native thread is required when native subagents are available. A self-review by the coordinator does not satisfy the independent review lane.
+- If native tools are unavailable, produce a prompt pack or continue as `single_agent` only after saying that no native threads were launched.
 
 ## Operating Contract
 
@@ -56,6 +94,10 @@ intent_contract:
     cadence:
     last_fetch:
     stale_base_policy:
+  thread_dispatch:
+    explicit_thread_request:
+    spawn_requirement:
+    no_spawn_reason:
 ```
 
 Defaults:
@@ -64,11 +106,11 @@ Defaults:
 - `data_collection` is `final_report` unless the user requests durable logging, debug data collection, or an issue/PR queue run explicitly sets `local_jsonl`.
 - If merge permission is ambiguous, stop after merge review and report the exact recommendation or merge command instead of merging.
 
-Direct actions: inspect repo instructions, fetch remote state, map lanes, spawn bounded native subagents when useful, integrate results, verify, and report closure.
+Direct actions: inspect repo instructions, fetch remote state, map lanes, apply the Explicit Thread Dispatch Gate, spawn required bounded native subagents, integrate results, verify, and report closure.
 
 Escalate before: modifying high-context files, merging without fresh CI/review-thread truth, sharing writable files across workers, or switching to shell/tmux/OMX orchestration.
 
-Evidence-backed pushback: choose `single_agent` when parallelism adds coordination risk without independent work; challenge vague worker output, stale remote state, or unverified completion claims.
+Evidence-backed pushback: choose `single_agent` only when parallelism adds coordination risk without independent work, and record the `no_spawn_reason`; challenge vague worker output, stale remote state, or unverified completion claims.
 
 Feedback loop: record notable failures in `threads_run_log`, classify the failure mode, tighten the lane prompt or split, then retry only after the hypothesis changes.
 
@@ -84,13 +126,17 @@ Before dispatching lanes, record whether native Codex subagents are actually ava
 capability_gate:
 - native_subagents: available | unavailable
 - tools_seen:
+- explicit_thread_request: yes | no
+- spawn_requirement: required | optional | unavailable
 - fallback_mode: single_agent | prompt_pack_only | none
+- no_spawn_reason:
 - manual_orchestration_allowed: yes | no
 ```
 
 Rules:
 
 - If native subagents are unavailable, do not claim threads were launched.
+- If native subagents are available and `spawn_requirement` is `required`, do not proceed past planning until at least one native subagent is spawned or `fallback_mode` and `no_spawn_reason` are recorded.
 - Do not switch to shell, tmux, OMX, Harness, or other manual orchestration unless the user explicitly asks for that fallback.
 - If `fallback_mode` is `single_agent`, explain why parallelism was rejected.
 - If `fallback_mode` is `prompt_pack_only`, output exact lane prompts and stop before implementation.
@@ -230,6 +276,8 @@ lanes:
   verification_scope: inspection_only | targeted | full_local | ci_only
   expected_output:
   verification:
+  native_thread_id:
+  no_spawn_reason:
 ```
 
 Rules:
@@ -237,6 +285,7 @@ Rules:
 - Search first: inspect repo state, open issues/PRs, current branch, dirty files, and applicable instructions before assigning work.
 - For GitHub queues, the lane map must be based on the preceding `queue_gate`; no worker lane may start from open issue/PR lists alone.
 - Keep planners and reviewers read-only.
+- Mark coordinator-only lanes with `native_thread_id: none`; every spawned lane must record the returned native tool agent ID.
 - Give implementation workers disjoint writable paths. Never assign two workers the same writable file.
 - Put high-context files such as `AGENTS.md`, `CLAUDE.md`, settings, hooks, and setup scripts in `forbidden_files` unless the user explicitly asks to modify them.
 - Prefer existing worktrees when they are already tied to the target branch. Otherwise create clean worktrees from `origin/main` or the requested base.
@@ -265,7 +314,7 @@ Rules:
 
 Use native subagents when available. If the multi-agent tool is not loaded, search for it using tool discovery. Do not use shell/tmux/OMX orchestration unless explicitly requested.
 
-When `multi_agent_v1` tools are available, use `spawn_agent` for bounded sidecar lanes, `wait_agent` only when the next critical-path step needs that result, and `close_agent` after collecting completed output. Keep immediate blockers in the main thread.
+When `multi_agent_v1` tools are available, use `spawn_agent` for required bounded sidecar lanes, `wait_agent` only when the next critical-path step needs that result, and `close_agent` after collecting completed output. Keep immediate blockers in the main thread, but do not count the main thread as a spawned native thread.
 
 Close completed subagents as soon as their evidence has been collected. For long issue/PR queues, finish a bounded tranche, record the ledger and resume query, and consider starting a fresh parent thread instead of carrying oversized context forward.
 
@@ -291,6 +340,7 @@ files_changed:
 unauthorized_or_unassigned_changes:
 commands_run:
 head_sha_or_artifact:
+native_thread_id:
 blockers:
 ```
 
@@ -301,6 +351,7 @@ Do not merge from worker output alone. Merge only after:
 - `merge_policy` is `merge_after_gate` or `user_confirm_before_merge` with explicit authorization from the current conversation.
 - `truth_level` is `A`; lower truth levels may produce recommendations but must not merge.
 - The PR/diff has at least one independent review lane.
+- When native subagents are available, the independent review lane must be a spawned native thread with a recorded tool agent ID.
 - Blocking findings are fixed or explicitly ruled out with evidence.
 - Required checks are fresh and tied to the current head SHA.
 - Current merge state is clean. `MERGEABLE`, `CLEAN`, or a green check alone is not sufficient without the matching current head SHA, full check rollup, merge state, and GraphQL review-thread state.
@@ -357,6 +408,11 @@ local_state:
 threads_run_log:
 - mode:
 - native_subagents:
+- explicit_thread_request:
+- spawn_requirement:
+- native_thread_evidence:
+    spawned_agents:
+- no_spawn_reason:
 - truth_level:
 - lanes_total:
 - queue_items_total:

--- a/skills/threads/agents/openai.yaml
+++ b/skills/threads/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Threads"
   short_description: "Coordinate native Codex threads with evidence gates and run logs"
-  default_prompt: "Use $threads only for explicit Codex-native subagent orchestration or repo queues with independent lanes. Default to single-agent when work is not clearly parallel, and require intent contracts, ownership, review gates, merge permission, truth levels, and evidence-backed closure."
+  default_prompt: "Use $threads only for explicit Codex-native subagent orchestration or repo queues with independent lanes. When the user explicitly asks for threads and native subagents are available, spawn at least one bounded native subagent or record a structured no_spawn_reason before implementation. Require intent contracts, ownership, native_thread_evidence, review gates, merge permission, truth levels, and evidence-backed closure."

--- a/skills/threads/references/prompt-patterns.md
+++ b/skills/threads/references/prompt-patterns.md
@@ -103,8 +103,8 @@ Target: {{issue_or_pr_or_queue}}
 
 输出：
 1. 目标摘要
-2. capability_gate（native_subagents / tools_seen / explicit_thread_request / spawn_requirement / fallback_mode）
-3. native_thread_evidence：spawned_agents 的 lane_id、spawn_tool、agent_id_or_thread_id、result_collected；若未 spawn，必须说明 fallback_reason
+2. capability_gate（native_subagents / tools_seen / explicit_thread_request / spawn_requirement / fallback_mode / no_spawn_reason）
+3. native_thread_evidence：spawned_agents 的 lane_id、spawn_tool、agent_id_or_thread_id、wait_evidence、close_evidence、result_collected；若未 spawn，必须说明 no_spawn_reason / fallback_reason
 4. intent_contract（含 merge_policy 默认 no_merge、truth_level、data_collection）
 5. queue_gate、queue_ledger 和 issue_to_pr_map（GitHub queue 必填；非 queue 说明 N/A）
 6. queue_bounds：max_items / time_budget / queue_tranche
@@ -273,6 +273,15 @@ No findings; safe to merge.
 开 {{n}} 个只读 researcher threads。
 默认 n<=3。不要修改文件，不要开 PR，不要 merge。
 
+先输出 thread_dispatch_gate：
+- explicit_thread_request
+- native_subagents
+- spawn_requirement
+- fallback_mode
+- planned_native_threads（每个 lane 的 id/role/target/spawn_status/no_spawn_reason）
+- native_thread_evidence.spawned_agents（每个实际 native thread 的 lane_id/spawn_tool/agent_id_or_thread_id/wait_evidence/close_evidence/result_collected）
+- no_spawn_reason（仅未 spawn 时允许）
+
 每个 thread 只负责一个明确角度：
 {{angles}}
 
@@ -286,6 +295,15 @@ No findings; safe to merge.
 不要修改文件，不要提交，不要 merge。
 默认 verification_scope=inspection_only；只运行便宜静态检查或 touched behavior targeted tests。
 不要运行 full project test suite，除非 lane_map 明确指定 reviewer 是 verification_owner 或 merge_reviewer。
+
+先输出 thread_dispatch_gate：
+- explicit_thread_request
+- native_subagents
+- spawn_requirement
+- fallback_mode
+- planned_native_threads（每个 lane 的 id/role/target/spawn_status/no_spawn_reason）
+- native_thread_evidence.spawned_agents（每个实际 native thread 的 lane_id/spawn_tool/agent_id_or_thread_id/wait_evidence/close_evidence/result_collected）
+- no_spawn_reason（仅未 spawn 时允许）
 
 输出 findings first；如果没有 blocking issue，写 No findings; safe to proceed。
 说明未验证项和残余风险。

--- a/skills/threads/references/prompt-patterns.md
+++ b/skills/threads/references/prompt-patterns.md
@@ -13,7 +13,9 @@ Use these templates as raw material. Fill concrete repo paths, PR numbers, issue
 硬约束：
 - 先查 repo 指令、git 状态、open issues、open PRs、CI、dirty worktree。
 - 只有用户明确要求 Codex-native threads / 子 agent 编排，或 GitHub issue/PR queue 确实需要独立 lanes 时才使用本流程；不要用于 OS/language/chat/email/forum/API threads。
-- 先写 capability_gate：native_subagents / tools_seen / fallback_mode / manual_orchestration_allowed；不能在 native subagents 不可用时声称开了 threads。
+- 先写 capability_gate：native_subagents / tools_seen / explicit_thread_request / spawn_requirement / fallback_mode / no_spawn_reason / manual_orchestration_allowed；不能在 native subagents 不可用时声称开了 threads。
+- 用户明确要求 threads/subagents 且 native_subagents=available 时，必须先 spawn 至少一个 native subagent，或在任何实现/评论/merge 前记录 `fallback_mode: single_agent` 和结构化 `no_spawn_reason`。
+- `native_subagents: available` + `fallback_mode: none` 只有在 `native_thread_evidence.spawned_agents` 里有真实 agent/thread ID 时才成立；main coordinator 不能算 spawned thread。
 - GitHub issue/PR queue 必须先输出 queue_gate 和 issue_to_pr_map，再输出 lane_map；不能只凭 MERGEABLE/CLEAN 或 open 列表开 worker。
 - 先写 intent_contract：goal / non_goals / done_when / merge_policy / remote_truth_required / truth_level / queue_ledger / ci_truth_source / data_collection / queue_bounds / remote_refresh。
 - merge_policy 默认 no_merge；只有用户在当前对话明确授权 merge，才允许 merge_after_gate。
@@ -21,6 +23,7 @@ Use these templates as raw material. Fill concrete repo paths, PR numbers, issue
 - queue_gate 必须包含 truth_level：A=GitHub API/GraphQL/head/check/reviewThreads 全新鲜；B=GraphQL 不可用但 REST 可用，禁止 merge；C=仅 local git，禁止 remote closure/merge；D=remote 不可靠，仅 plan/prompt pack。
 - queue_gate 必须包含 remote_refresh：origin/main 当前 SHA、lane base SHA、是否 stale_base、处理策略。
 - 输出 queue_ledger，并在每个 queue item 上记录 owner_lane、head_sha、ci_status、review_thread_state、acceptance_evidence、remote_checked_at。
+- lane_map 每个 spawned lane 必须记录 `native_thread_id`；coordinator-only lane 必须写 `native_thread_id: none` 和需要时的 `no_spawn_reason`。
 - issue_to_pr_map 必须先判断 open issue 是否已有覆盖 PR；优先收敛已有 PR，不要开竞争 PR。
 - data_collection 默认 final_report；只有用户要求 durable logging 或 debug collection 时才写 local_jsonl。
 - broad queue 默认只做一个 bounded tranche；没有明确预算时不要承诺处理所有 issue/PR。
@@ -37,10 +40,11 @@ Use these templates as raw material. Fill concrete repo paths, PR numbers, issue
 - 完成的 subagent 要及时 close；长 issue/PR 队列完成一个 bounded tranche 后，记录 ledger/resume query，并考虑开新 parent thread 降低上下文负担。
 - 高上下文文件 AGENTS.md/CLAUDE.md/settings/hooks 默认禁止修改。
 - 每个 PR merge 前必须有独立 thread review。
+- 当 native_subagents=available 时，merge 前的独立 review 必须来自 spawned native thread，并在 `native_thread_evidence` 记录 agent/thread ID、wait evidence、close evidence。
 - merge 前必须 truth_level=A，并用 thread-aware GitHub 数据检查 reviewThreads.isResolved；open PR/issue 为空不等于评论闭环完成。
 - CI wait 必须有预算；无本地可行动失败时用 WAITING_CI 停止并给 resume 查询。
 - review-thread fix/recheck 同类循环超过 2 次，用 REVIEW_LOOP 停止并报告 blocker。
-- 输出 capability_gate、queue_gate、queue_ledger、issue_to_pr_map、lane_map、依赖图、执行顺序、验证命令、stop_conditions、threads_run_log。
+- 输出 capability_gate、thread_dispatch_gate、native_thread_evidence、queue_gate、queue_ledger、issue_to_pr_map、lane_map、依赖图、执行顺序、验证命令、stop_conditions、threads_run_log。
 ```
 
 ## Queue Gate Thread
@@ -99,19 +103,20 @@ Target: {{issue_or_pr_or_queue}}
 
 输出：
 1. 目标摘要
-2. capability_gate（native_subagents / tools_seen / fallback_mode）
-3. intent_contract（含 merge_policy 默认 no_merge、truth_level、data_collection）
-4. queue_gate、queue_ledger 和 issue_to_pr_map（GitHub queue 必填；非 queue 说明 N/A）
-5. queue_bounds：max_items / time_budget / queue_tranche
-6. remote_refresh：origin/main SHA、stale_base 判断、处理建议
-7. 已完成映射和证据
-8. 未完成/风险
-9. 推荐处理动作和理由
-10. 可并行 worktree 拆分
-11. 每个 lane 的 writable_files、forbidden_files、exclusive_verification、verification_scope
-12. 必须运行的验证命令
-13. 不应在本轮强做的范围
-14. 建议的 failure_codes（如 stale_remote_state、duplicate_work_missed、missing_intent_contract）
+2. capability_gate（native_subagents / tools_seen / explicit_thread_request / spawn_requirement / fallback_mode）
+3. native_thread_evidence：spawned_agents 的 lane_id、spawn_tool、agent_id_or_thread_id、result_collected；若未 spawn，必须说明 fallback_reason
+4. intent_contract（含 merge_policy 默认 no_merge、truth_level、data_collection）
+5. queue_gate、queue_ledger 和 issue_to_pr_map（GitHub queue 必填；非 queue 说明 N/A）
+6. queue_bounds：max_items / time_budget / queue_tranche
+7. remote_refresh：origin/main SHA、stale_base 判断、处理建议
+8. 已完成映射和证据
+9. 未完成/风险
+10. 推荐处理动作和理由
+11. 可并行 worktree 拆分
+12. 每个 lane 的 writable_files、forbidden_files、exclusive_verification、verification_scope、native_thread_id
+13. 必须运行的验证命令
+14. 不应在本轮强做的范围
+15. 建议的 failure_codes（如 stale_remote_state、duplicate_work_missed、missing_intent_contract、native_thread_not_spawned）
 ```
 
 ## Implementation Worker
@@ -322,6 +327,8 @@ No findings; safe to merge.
 - mode
 - repo
 - lanes_total
+- native_thread_evidence.spawned_agents
+- no_spawn_reason
 - failure_codes
 - verification.fresh
 - truth_level

--- a/skills/threads/references/run-log.md
+++ b/skills/threads/references/run-log.md
@@ -58,7 +58,19 @@ python3 skills/threads/scripts/append_run_log.py <<'JSON'
   },
   "truth_level": "A",
   "native_subagents": "available",
+  "explicit_thread_request": true,
+  "spawn_requirement": "required",
   "fallback_mode": "none",
+  "native_thread_evidence": {
+    "spawned_agents": [
+      {
+        "lane_id": "merge-reviewer",
+        "spawn_tool": "multi_agent_v1.spawn_agent",
+        "agent_id_or_thread_id": "agent-123",
+        "result_collected": true
+      }
+    ]
+  },
   "queue_bounds": {
     "max_items": 1,
     "time_budget": "30m",
@@ -110,7 +122,27 @@ Recommended fields:
   },
   "truth_level": "A|B|C|D",
   "native_subagents": "available|unavailable",
+  "explicit_thread_request": true,
+  "spawn_requirement": "required|optional|unavailable",
   "fallback_mode": "none|single_agent|prompt_pack_only",
+  "no_spawn_reason": "required when an explicit threads run falls back to single_agent",
+  "single_agent_justification": {
+    "reason": "no_independent_lanes|sequential_dependency|shared_writable_files|tool_unavailable|user_requested_single_agent",
+    "evidence": "short evidence summary"
+  },
+  "native_thread_evidence": {
+    "spawned_agents": [
+      {
+        "lane_id": "review-pr",
+        "spawn_tool": "multi_agent_v1.spawn_agent",
+        "agent_id_or_thread_id": "agent-123",
+        "wait_evidence": "completed status collected",
+        "close_evidence": "closed after collection",
+        "result_collected": true
+      }
+    ],
+    "fallback_reason": ""
+  },
   "queue_bounds": {
     "max_items": 1,
     "time_budget": "30m",
@@ -139,6 +171,7 @@ Recommended fields:
       "worktree": "/tmp/repo-worker-1",
       "writable_files": ["src/example.rs"],
       "files_changed": ["src/example.rs"],
+      "native_thread_id": "agent-123",
       "verification_scope": "targeted",
       "verification": ["cargo test example"],
       "result": "passed|blocked|failed"
@@ -223,6 +256,7 @@ Use stable codes so later analysis can aggregate them:
 - `verification_gap`: completion was claimed without fresh command output.
 - `review_thread_missed`: inline review thread/comment state was not checked.
 - `review_loop`: repeated review-thread fix cycles hit the configured limit.
+- `native_thread_not_spawned`: explicit threads run did not spawn a native subagent and did not record a valid fallback.
 - `waiting_ci`: only remote CI remained and the wait budget was exhausted.
 - `merge_gate_bypass`: merge happened without independent review or closure audit.
 - `tool_unavailable`: native subagent, GitHub, or validation tool was unavailable.

--- a/skills/threads/references/run-log.md
+++ b/skills/threads/references/run-log.md
@@ -67,6 +67,8 @@ python3 skills/threads/scripts/append_run_log.py <<'JSON'
         "lane_id": "merge-reviewer",
         "spawn_tool": "multi_agent_v1.spawn_agent",
         "agent_id_or_thread_id": "agent-123",
+        "wait_evidence": "wait_agent completed",
+        "close_evidence": "close_agent completed",
         "result_collected": true
       }
     ]
@@ -125,7 +127,7 @@ Recommended fields:
   "explicit_thread_request": true,
   "spawn_requirement": "required|optional|unavailable",
   "fallback_mode": "none|single_agent|prompt_pack_only",
-  "no_spawn_reason": "required when an explicit threads run falls back to single_agent",
+  "no_spawn_reason": "required when an explicit threads run falls back to single_agent; use no_independent_lanes|sequential_dependency|shared_writable_files|tool_unavailable|user_requested_single_agent",
   "single_agent_justification": {
     "reason": "no_independent_lanes|sequential_dependency|shared_writable_files|tool_unavailable|user_requested_single_agent",
     "evidence": "short evidence summary"

--- a/skills/threads/scripts/append_run_log.py
+++ b/skills/threads/scripts/append_run_log.py
@@ -56,7 +56,12 @@ ALLOWED_TOP_LEVEL_FIELDS = {
     "data_collection",
     "truth_level",
     "native_subagents",
+    "explicit_thread_request",
+    "spawn_requirement",
+    "native_thread_evidence",
     "fallback_mode",
+    "no_spawn_reason",
+    "single_agent_justification",
     "capability_gate",
     "queue_bounds",
     "remote_refresh",
@@ -166,10 +171,85 @@ def normalize_record(raw: Any, allow_extra: bool = False) -> dict[str, Any]:
     truth_level = record.get("truth_level")
     if truth_level is not None and truth_level not in ALLOWED_TRUTH_LEVELS:
         raise ValueError(f"unknown truth_level: {truth_level}")
+    validate_native_thread_evidence(record)
 
     record.setdefault("schema_version", 1)
     record["recorded_at_utc"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
     return record
+
+
+def truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"yes", "true", "1", "required"}
+    return False
+
+
+def nested_get(mapping: dict[str, Any], field: str) -> Any:
+    nested = mapping.get("capability_gate")
+    if isinstance(nested, dict) and field in nested:
+        return nested.get(field)
+    return mapping.get(field)
+
+
+def has_spawned_agent(record: dict[str, Any]) -> bool:
+    evidence = record.get("native_thread_evidence")
+    if not isinstance(evidence, dict):
+        return False
+    spawned_agents = evidence.get("spawned_agents")
+    if not isinstance(spawned_agents, list):
+        return False
+    for agent in spawned_agents:
+        if not isinstance(agent, dict):
+            continue
+        if agent.get("agent_id_or_thread_id") or agent.get("tool_agent_id"):
+            return True
+    return False
+
+
+def has_single_agent_reason(record: dict[str, Any]) -> bool:
+    if record.get("no_spawn_reason"):
+        return True
+    justification = record.get("single_agent_justification")
+    if isinstance(justification, dict) and justification.get("reason"):
+        return True
+    evidence = record.get("native_thread_evidence")
+    return isinstance(evidence, dict) and bool(evidence.get("fallback_reason"))
+
+
+def validate_native_thread_evidence(record: dict[str, Any]) -> None:
+    mode = record.get("mode")
+    native_subagents = nested_get(record, "native_subagents")
+    fallback_mode = nested_get(record, "fallback_mode")
+    explicit_request = nested_get(record, "explicit_thread_request")
+    spawn_requirement = nested_get(record, "spawn_requirement")
+    dispatch_mode = mode in {"execute_direct", "review_only", "research_spec"}
+    required = truthy(explicit_request) or spawn_requirement == "required"
+
+    if (
+        dispatch_mode
+        and native_subagents == "available"
+        and fallback_mode == "none"
+        and required
+        and not has_spawned_agent(record)
+    ):
+        raise ValueError(
+            "native_thread_evidence.spawned_agents is required when native "
+            "subagents are available for an explicit threads run"
+        )
+
+    if (
+        dispatch_mode
+        and native_subagents == "available"
+        and fallback_mode == "single_agent"
+        and required
+        and not has_single_agent_reason(record)
+    ):
+        raise ValueError(
+            "single_agent fallback for an explicit threads run requires "
+            "no_spawn_reason or single_agent_justification.reason"
+        )
 
 
 def append_record(record: dict[str, Any], path: Path) -> None:

--- a/skills/threads/scripts/append_run_log.py
+++ b/skills/threads/scripts/append_run_log.py
@@ -367,7 +367,13 @@ def validate_native_thread_evidence(record: dict[str, Any]) -> None:
     fallback_mode = nested_get(record, "fallback_mode")
     explicit_request = nested_get(record, "explicit_thread_request")
     spawn_requirement = nested_get(record, "spawn_requirement")
-    dispatch_mode = mode in {"plan_only", "execute_direct", "review_only", "research_spec"}
+    dispatch_mode = mode in {
+        "single_agent",
+        "plan_only",
+        "execute_direct",
+        "review_only",
+        "research_spec",
+    }
     required = truthy(explicit_request) or spawn_requirement == "required"
 
     if fallback_mode is not None and fallback_mode not in ALLOWED_FALLBACK_MODES:

--- a/skills/threads/scripts/append_run_log.py
+++ b/skills/threads/scripts/append_run_log.py
@@ -40,6 +40,16 @@ ALLOWED_MODES = {
     "clarify_first",
 }
 ALLOWED_TRUTH_LEVELS = {"A", "B", "C", "D"}
+ALLOWED_FALLBACK_MODES = {"none", "single_agent", "prompt_pack_only"}
+ALLOWED_NATIVE_SPAWN_TOOLS = {"multi_agent_v1.spawn_agent"}
+INVALID_AGENT_IDS = {"", "none", "n/a", "na", "null", "main", "main_thread", "coordinator"}
+ALLOWED_SINGLE_AGENT_REASONS = {
+    "no_independent_lanes",
+    "sequential_dependency",
+    "shared_writable_files",
+    "tool_unavailable",
+    "user_requested_single_agent",
+}
 ALLOWED_TOP_LEVEL_FIELDS = {
     "schema_version",
     "recorded_at_utc",
@@ -63,6 +73,7 @@ ALLOWED_TOP_LEVEL_FIELDS = {
     "no_spawn_reason",
     "single_agent_justification",
     "capability_gate",
+    "thread_dispatch_gate",
     "queue_bounds",
     "remote_refresh",
     "queue_ledger",
@@ -186,16 +197,55 @@ def truthy(value: Any) -> bool:
     return False
 
 
+def canonical_gate_value(field: str, value: Any) -> Any:
+    if field == "explicit_thread_request":
+        return truthy(value)
+    return value
+
+
 def nested_get(mapping: dict[str, Any], field: str) -> Any:
-    nested = mapping.get("capability_gate")
-    if isinstance(nested, dict) and field in nested:
-        return nested.get(field)
-    return mapping.get(field)
+    values: list[tuple[str, Any]] = []
+    if field in mapping:
+        values.append(("top-level", mapping.get(field)))
+    for container in ("capability_gate", "thread_dispatch_gate"):
+        nested = mapping.get(container)
+        if isinstance(nested, dict) and field in nested:
+            values.append((container, nested.get(field)))
+
+    present = [(source, value) for source, value in values if value is not None]
+    if not present:
+        return None
+    canonical_values = {
+        canonical_gate_value(field, value)
+        for _, value in present
+    }
+    if len(canonical_values) > 1:
+        sources = ", ".join(source for source, _ in present)
+        raise ValueError(f"conflicting {field} values across {sources}")
+    return present[0][1]
+
+
+def native_thread_evidence(record: dict[str, Any]) -> dict[str, Any] | None:
+    evidence = record.get("native_thread_evidence")
+    if isinstance(evidence, dict):
+        return evidence
+    dispatch_gate = record.get("thread_dispatch_gate")
+    if isinstance(dispatch_gate, dict):
+        nested = dispatch_gate.get("native_thread_evidence")
+        if isinstance(nested, dict):
+            return nested
+    return None
+
+
+def valid_agent_id(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    return value.strip().lower() not in INVALID_AGENT_IDS
 
 
 def has_spawned_agent(record: dict[str, Any]) -> bool:
-    evidence = record.get("native_thread_evidence")
-    if not isinstance(evidence, dict):
+    evidence = native_thread_evidence(record)
+    if evidence is None:
         return False
     spawned_agents = evidence.get("spawned_agents")
     if not isinstance(spawned_agents, list):
@@ -203,19 +253,51 @@ def has_spawned_agent(record: dict[str, Any]) -> bool:
     for agent in spawned_agents:
         if not isinstance(agent, dict):
             continue
-        if agent.get("agent_id_or_thread_id") or agent.get("tool_agent_id"):
+        agent_id = agent.get("agent_id_or_thread_id") or agent.get("tool_agent_id")
+        if (
+            agent.get("spawn_tool") in ALLOWED_NATIVE_SPAWN_TOOLS
+            and valid_agent_id(agent_id)
+            and agent.get("result_collected") is True
+            and bool(agent.get("wait_evidence"))
+            and bool(agent.get("close_evidence"))
+        ):
             return True
     return False
 
 
+def normalize_reason(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+    return normalized or None
+
+
+def allowed_reason(reason: Any, evidence: Any = None) -> bool:
+    normalized = normalize_reason(reason)
+    if normalized not in ALLOWED_SINGLE_AGENT_REASONS:
+        return False
+    return evidence is None or bool(evidence)
+
+
 def has_single_agent_reason(record: dict[str, Any]) -> bool:
-    if record.get("no_spawn_reason"):
+    no_spawn_reason = record.get("no_spawn_reason")
+    if isinstance(no_spawn_reason, dict):
+        if allowed_reason(no_spawn_reason.get("reason"), no_spawn_reason.get("evidence")):
+            return True
+    elif allowed_reason(no_spawn_reason):
         return True
+
     justification = record.get("single_agent_justification")
-    if isinstance(justification, dict) and justification.get("reason"):
+    if (
+        isinstance(justification, dict)
+        and allowed_reason(justification.get("reason"), justification.get("evidence"))
+    ):
         return True
-    evidence = record.get("native_thread_evidence")
-    return isinstance(evidence, dict) and bool(evidence.get("fallback_reason"))
+
+    evidence = native_thread_evidence(record)
+    if not isinstance(evidence, dict):
+        return False
+    return allowed_reason(evidence.get("fallback_reason"))
 
 
 def validate_native_thread_evidence(record: dict[str, Any]) -> None:
@@ -224,14 +306,23 @@ def validate_native_thread_evidence(record: dict[str, Any]) -> None:
     fallback_mode = nested_get(record, "fallback_mode")
     explicit_request = nested_get(record, "explicit_thread_request")
     spawn_requirement = nested_get(record, "spawn_requirement")
-    dispatch_mode = mode in {"execute_direct", "review_only", "research_spec"}
+    dispatch_mode = mode in {"plan_only", "execute_direct", "review_only", "research_spec"}
     required = truthy(explicit_request) or spawn_requirement == "required"
 
+    if fallback_mode is not None and fallback_mode not in ALLOWED_FALLBACK_MODES:
+        raise ValueError(f"unknown fallback_mode: {fallback_mode}")
+
+    explicit_native_required = dispatch_mode and native_subagents == "available" and required
+
+    if explicit_native_required and fallback_mode is None:
+        raise ValueError(
+            "fallback_mode is required when native subagents are available "
+            "for an explicit threads run"
+        )
+
     if (
-        dispatch_mode
-        and native_subagents == "available"
+        explicit_native_required
         and fallback_mode == "none"
-        and required
         and not has_spawned_agent(record)
     ):
         raise ValueError(
@@ -240,15 +331,19 @@ def validate_native_thread_evidence(record: dict[str, Any]) -> None:
         )
 
     if (
-        dispatch_mode
-        and native_subagents == "available"
+        explicit_native_required
         and fallback_mode == "single_agent"
-        and required
         and not has_single_agent_reason(record)
     ):
         raise ValueError(
             "single_agent fallback for an explicit threads run requires "
-            "no_spawn_reason or single_agent_justification.reason"
+            "an allowed no_spawn_reason or single_agent_justification.reason"
+        )
+
+    if explicit_native_required and fallback_mode == "prompt_pack_only":
+        raise ValueError(
+            "prompt_pack_only fallback is invalid when native subagents are "
+            "available for an explicit threads run"
         )
 
 

--- a/skills/threads/scripts/append_run_log.py
+++ b/skills/threads/scripts/append_run_log.py
@@ -237,19 +237,25 @@ def native_thread_evidence(record: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
+def thread_dispatch_gate(record: dict[str, Any]) -> dict[str, Any] | None:
+    gate = record.get("thread_dispatch_gate")
+    return gate if isinstance(gate, dict) else None
+
+
 def valid_agent_id(value: Any) -> bool:
     if not isinstance(value, str):
         return False
     return value.strip().lower() not in INVALID_AGENT_IDS
 
 
-def has_spawned_agent(record: dict[str, Any]) -> bool:
+def valid_spawned_agents(record: dict[str, Any]) -> list[dict[str, Any]]:
     evidence = native_thread_evidence(record)
     if evidence is None:
-        return False
+        return []
     spawned_agents = evidence.get("spawned_agents")
     if not isinstance(spawned_agents, list):
-        return False
+        return []
+    valid_agents = []
     for agent in spawned_agents:
         if not isinstance(agent, dict):
             continue
@@ -261,8 +267,12 @@ def has_spawned_agent(record: dict[str, Any]) -> bool:
             and bool(agent.get("wait_evidence"))
             and bool(agent.get("close_evidence"))
         ):
-            return True
-    return False
+            valid_agents.append(agent)
+    return valid_agents
+
+
+def has_spawned_agent(record: dict[str, Any]) -> bool:
+    return bool(valid_spawned_agents(record))
 
 
 def normalize_reason(value: Any) -> str | None:
@@ -287,6 +297,15 @@ def has_single_agent_reason(record: dict[str, Any]) -> bool:
     elif allowed_reason(no_spawn_reason):
         return True
 
+    gate = thread_dispatch_gate(record)
+    if gate is not None:
+        gate_reason = gate.get("no_spawn_reason")
+        if isinstance(gate_reason, dict):
+            if allowed_reason(gate_reason.get("reason"), gate_reason.get("evidence")):
+                return True
+        elif allowed_reason(gate_reason):
+            return True
+
     justification = record.get("single_agent_justification")
     if (
         isinstance(justification, dict)
@@ -298,6 +317,48 @@ def has_single_agent_reason(record: dict[str, Any]) -> bool:
     if not isinstance(evidence, dict):
         return False
     return allowed_reason(evidence.get("fallback_reason"))
+
+
+def lane_has_no_spawn_reason(lane: dict[str, Any]) -> bool:
+    reason = lane.get("no_spawn_reason")
+    if isinstance(reason, dict):
+        return allowed_reason(reason.get("reason"), reason.get("evidence"))
+    return allowed_reason(reason)
+
+
+def validate_planned_native_threads(record: dict[str, Any]) -> None:
+    gate = thread_dispatch_gate(record)
+    if gate is None:
+        return
+    planned_threads = gate.get("planned_native_threads")
+    if planned_threads is None:
+        return
+    if not isinstance(planned_threads, list):
+        raise ValueError("thread_dispatch_gate.planned_native_threads must be a list")
+
+    spawned_lane_ids = {
+        agent.get("lane_id")
+        for agent in valid_spawned_agents(record)
+        if isinstance(agent.get("lane_id"), str) and agent.get("lane_id")
+    }
+    missing_reasons = []
+    for lane in planned_threads:
+        if not isinstance(lane, dict):
+            raise ValueError("thread_dispatch_gate.planned_native_threads entries must be objects")
+        lane_id = lane.get("id") or lane.get("lane_id")
+        if not lane_id:
+            raise ValueError("thread_dispatch_gate.planned_native_threads entries require id")
+        if lane_id in spawned_lane_ids:
+            continue
+        if lane_has_no_spawn_reason(lane):
+            continue
+        missing_reasons.append(str(lane_id))
+
+    if missing_reasons:
+        raise ValueError(
+            "thread_dispatch_gate.planned_native_threads missing spawned evidence "
+            "or no_spawn_reason for lane(s): " + ", ".join(missing_reasons)
+        )
 
 
 def validate_native_thread_evidence(record: dict[str, Any]) -> None:
@@ -345,6 +406,9 @@ def validate_native_thread_evidence(record: dict[str, Any]) -> None:
             "prompt_pack_only fallback is invalid when native subagents are "
             "available for an explicit threads run"
         )
+
+    if explicit_native_required and fallback_mode == "none":
+        validate_planned_native_threads(record)
 
 
 def append_record(record: dict[str, Any], path: Path) -> None:

--- a/tests/test_threads_run_log.py
+++ b/tests/test_threads_run_log.py
@@ -510,6 +510,26 @@ class ThreadsRunLogTests(unittest.TestCase):
             self.assertIn("single_agent fallback", result.stderr)
             self.assertFalse(log_path.exists())
 
+    def test_rejects_explicit_single_agent_mode_without_fallback_reason(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "single-agent-mode-missing.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "single_agent",
+                    "native_subagents": "available",
+                    "explicit_thread_request": "yes",
+                    "spawn_requirement": "required",
+                    "fallback_mode": "none",
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("native_thread_evidence.spawned_agents", result.stderr)
+            self.assertFalse(log_path.exists())
+
     def test_accepts_reasoned_explicit_single_agent_fallback(self):
         with TemporaryDirectory() as temp_dir:
             log_path = Path(temp_dir) / "fallback-reason.jsonl"

--- a/tests/test_threads_run_log.py
+++ b/tests/test_threads_run_log.py
@@ -13,6 +13,15 @@ SCRIPT = ROOT / "skills" / "threads" / "scripts" / "append_run_log.py"
 
 
 class ThreadsRunLogTests(unittest.TestCase):
+    def run_script(self, payload, log_path, *extra_args):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--path", str(log_path), *extra_args],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
     def test_appends_sanitized_jsonl_record(self):
         with TemporaryDirectory() as temp_dir:
             log_path = Path(temp_dir) / "threads.jsonl"
@@ -205,6 +214,8 @@ class ThreadsRunLogTests(unittest.TestCase):
                                     "lane_id": "review-pr",
                                     "spawn_tool": "multi_agent_v1.spawn_agent",
                                     "agent_id_or_thread_id": "agent-123",
+                                    "wait_evidence": "wait_agent completed",
+                                    "close_evidence": "close_agent completed",
                                     "result_collected": True,
                                 }
                             ]
@@ -221,6 +232,177 @@ class ThreadsRunLogTests(unittest.TestCase):
             record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
             self.assertEqual(
                 record["native_thread_evidence"]["spawned_agents"][0]["agent_id_or_thread_id"],
+                "agent-123",
+            )
+
+    def test_rejects_required_native_threads_without_fallback_mode(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "fallback-omitted.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "execute_direct",
+                    "native_subagents": "available",
+                    "explicit_thread_request": True,
+                    "spawn_requirement": "required",
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("fallback_mode is required", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_rejects_prompt_pack_fallback_when_native_threads_available(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "prompt-pack.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "review_only",
+                    "native_subagents": "available",
+                    "explicit_thread_request": True,
+                    "spawn_requirement": "required",
+                    "fallback_mode": "prompt_pack_only",
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("prompt_pack_only fallback is invalid", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_rejects_invalid_fallback_mode_for_required_native_threads(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "invalid-fallback.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "execute_direct",
+                    "native_subagents": "available",
+                    "explicit_thread_request": True,
+                    "spawn_requirement": "required",
+                    "fallback_mode": "serial",
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unknown fallback_mode", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_rejects_fake_native_thread_evidence(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "fake-native.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "execute_direct",
+                    "native_subagents": "available",
+                    "explicit_thread_request": True,
+                    "spawn_requirement": "required",
+                    "fallback_mode": "none",
+                    "native_thread_evidence": {
+                        "spawned_agents": [
+                            {
+                                "lane_id": "review-pr",
+                                "spawn_tool": "manual",
+                                "agent_id_or_thread_id": "none",
+                                "result_collected": False,
+                            }
+                        ]
+                    },
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("native_thread_evidence.spawned_agents", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_rejects_conflicting_capability_gate(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "conflict.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "execute_direct",
+                    "native_subagents": "available",
+                    "explicit_thread_request": True,
+                    "spawn_requirement": "required",
+                    "fallback_mode": "none",
+                    "capability_gate": {
+                        "native_subagents": "unavailable",
+                    },
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("conflicting native_subagents", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_rejects_explicit_plan_only_without_spawned_agent(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "plan-only-missing.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "plan_only",
+                    "native_subagents": "available",
+                    "explicit_thread_request": True,
+                    "spawn_requirement": "required",
+                    "fallback_mode": "none",
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("native_thread_evidence.spawned_agents", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_accepts_thread_dispatch_gate_spawned_agent(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "dispatch-gate.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "review_only",
+                    "thread_dispatch_gate": {
+                        "native_subagents": "available",
+                        "explicit_thread_request": True,
+                        "spawn_requirement": "required",
+                        "fallback_mode": "none",
+                        "native_thread_evidence": {
+                            "spawned_agents": [
+                                {
+                                    "lane_id": "review-pr",
+                                    "spawn_tool": "multi_agent_v1.spawn_agent",
+                                    "agent_id_or_thread_id": "agent-123",
+                                    "wait_evidence": "wait_agent completed",
+                                    "close_evidence": "close_agent completed",
+                                    "result_collected": True,
+                                }
+                            ]
+                        },
+                    },
+                },
+                log_path,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(
+                record["thread_dispatch_gate"]["native_thread_evidence"]["spawned_agents"][0][
+                    "agent_id_or_thread_id"
+                ],
                 "agent-123",
             )
 
@@ -280,6 +462,30 @@ class ThreadsRunLogTests(unittest.TestCase):
                 record["single_agent_justification"]["reason"],
                 "sequential_dependency",
             )
+
+    def test_rejects_invalid_explicit_single_agent_fallback_reason(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "fallback-invalid-reason.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "review_only",
+                    "native_subagents": "available",
+                    "explicit_thread_request": "yes",
+                    "spawn_requirement": "required",
+                    "fallback_mode": "single_agent",
+                    "single_agent_justification": {
+                        "reason": "too_hard",
+                        "evidence": "vague",
+                    },
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("single_agent fallback", result.stderr)
+            self.assertFalse(log_path.exists())
 
     def test_rejects_non_object_input(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_threads_run_log.py
+++ b/tests/test_threads_run_log.py
@@ -406,6 +406,85 @@ class ThreadsRunLogTests(unittest.TestCase):
                 "agent-123",
             )
 
+    def test_rejects_planned_native_thread_without_spawn_or_reason(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "planned-missing.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "review_only",
+                    "thread_dispatch_gate": {
+                        "native_subagents": "available",
+                        "explicit_thread_request": True,
+                        "spawn_requirement": "required",
+                        "fallback_mode": "none",
+                        "planned_native_threads": [
+                            {"id": "review-docs", "role": "reviewer"},
+                            {"id": "review-tests", "role": "reviewer"},
+                        ],
+                        "native_thread_evidence": {
+                            "spawned_agents": [
+                                {
+                                    "lane_id": "review-docs",
+                                    "spawn_tool": "multi_agent_v1.spawn_agent",
+                                    "agent_id_or_thread_id": "agent-123",
+                                    "wait_evidence": "wait_agent completed",
+                                    "close_evidence": "close_agent completed",
+                                    "result_collected": True,
+                                }
+                            ]
+                        },
+                    },
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("planned_native_threads missing spawned evidence", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_accepts_planned_native_thread_with_lane_no_spawn_reason(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "planned-reason.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "review_only",
+                    "thread_dispatch_gate": {
+                        "native_subagents": "available",
+                        "explicit_thread_request": True,
+                        "spawn_requirement": "required",
+                        "fallback_mode": "none",
+                        "planned_native_threads": [
+                            {"id": "review-docs", "role": "reviewer"},
+                            {
+                                "id": "review-tests",
+                                "role": "reviewer",
+                                "no_spawn_reason": "sequential_dependency",
+                            },
+                        ],
+                        "native_thread_evidence": {
+                            "spawned_agents": [
+                                {
+                                    "lane_id": "review-docs",
+                                    "spawn_tool": "multi_agent_v1.spawn_agent",
+                                    "agent_id_or_thread_id": "agent-123",
+                                    "wait_evidence": "wait_agent completed",
+                                    "close_evidence": "close_agent completed",
+                                    "result_collected": True,
+                                }
+                            ]
+                        },
+                    },
+                },
+                log_path,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(log_path.exists())
+
     def test_requires_reason_for_explicit_single_agent_fallback(self):
         with TemporaryDirectory() as temp_dir:
             log_path = Path(temp_dir) / "fallback-missing.jsonl"
@@ -462,6 +541,28 @@ class ThreadsRunLogTests(unittest.TestCase):
                 record["single_agent_justification"]["reason"],
                 "sequential_dependency",
             )
+
+    def test_accepts_thread_dispatch_gate_single_agent_reason(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "dispatch-fallback-reason.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "review_only",
+                    "thread_dispatch_gate": {
+                        "native_subagents": "available",
+                        "explicit_thread_request": True,
+                        "spawn_requirement": "required",
+                        "fallback_mode": "single_agent",
+                        "no_spawn_reason": "sequential_dependency",
+                    },
+                },
+                log_path,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(log_path.exists())
 
     def test_rejects_invalid_explicit_single_agent_fallback_reason(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_threads_run_log.py
+++ b/tests/test_threads_run_log.py
@@ -159,6 +159,128 @@ class ThreadsRunLogTests(unittest.TestCase):
             record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
             self.assertEqual(record["mode"], "clarify_first")
 
+    def test_rejects_required_native_threads_without_spawned_agent(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "native-missing.jsonl"
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--path", str(log_path)],
+                input=json.dumps(
+                    {
+                        "skill": "threads",
+                        "mode": "execute_direct",
+                        "native_subagents": "available",
+                        "explicit_thread_request": True,
+                        "spawn_requirement": "required",
+                        "fallback_mode": "none",
+                        "lanes_total": 2,
+                    }
+                ),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("native_thread_evidence.spawned_agents", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_accepts_required_native_threads_with_spawned_agent(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "native-present.jsonl"
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--path", str(log_path)],
+                input=json.dumps(
+                    {
+                        "skill": "threads",
+                        "mode": "execute_direct",
+                        "native_subagents": "available",
+                        "explicit_thread_request": True,
+                        "spawn_requirement": "required",
+                        "fallback_mode": "none",
+                        "native_thread_evidence": {
+                            "spawned_agents": [
+                                {
+                                    "lane_id": "review-pr",
+                                    "spawn_tool": "multi_agent_v1.spawn_agent",
+                                    "agent_id_or_thread_id": "agent-123",
+                                    "result_collected": True,
+                                }
+                            ]
+                        },
+                        "lanes_total": 2,
+                    }
+                ),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(
+                record["native_thread_evidence"]["spawned_agents"][0]["agent_id_or_thread_id"],
+                "agent-123",
+            )
+
+    def test_requires_reason_for_explicit_single_agent_fallback(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "fallback-missing.jsonl"
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--path", str(log_path)],
+                input=json.dumps(
+                    {
+                        "skill": "threads",
+                        "mode": "review_only",
+                        "native_subagents": "available",
+                        "explicit_thread_request": "yes",
+                        "spawn_requirement": "required",
+                        "fallback_mode": "single_agent",
+                    }
+                ),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("single_agent fallback", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_accepts_reasoned_explicit_single_agent_fallback(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "fallback-reason.jsonl"
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--path", str(log_path)],
+                input=json.dumps(
+                    {
+                        "skill": "threads",
+                        "mode": "review_only",
+                        "native_subagents": "available",
+                        "explicit_thread_request": "yes",
+                        "spawn_requirement": "required",
+                        "fallback_mode": "single_agent",
+                        "single_agent_justification": {
+                            "reason": "sequential_dependency",
+                            "evidence": "next step depends on one immediate result",
+                        },
+                    }
+                ),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(
+                record["single_agent_justification"]["reason"],
+                "sequential_dependency",
+            )
+
     def test_rejects_non_object_input(self):
         with TemporaryDirectory() as temp_dir:
             log_path = Path(temp_dir) / "bad.jsonl"


### PR DESCRIPTION
Closes #84

## Summary

- adds an explicit thread dispatch gate to the `threads` skill so explicit thread/subagent requests require real native subagent evidence when tools are available
- records `native_thread_evidence`, `native_thread_id`, and structured single-agent fallback reasons in the skill contract, prompt templates, run-log schema, and final report shape
- validates run-log records so explicit native-thread runs cannot report `fallback_mode: none` without spawned agent IDs

## Validation

- `git diff --check`
- `python3 -m unittest discover -s tests -p test_threads_run_log.py`
- `python3 scripts/validate_skills.py --check`
- `python3 scripts/audit_skill_quality.py threads`
- `python3 -m pytest`