### PR TITLE
Validate script dependency declarations

### DIFF
--- a/scripts/skill_dependency_checks.py
+++ b/scripts/skill_dependency_checks.py
@@ -20,11 +20,13 @@ LOCAL_SCRIPT_IMPORT_ROOTS = {
     "scripts",
 }
 
-BEAUTIFULSOUP_LXML_RE = re.compile(r"BeautifulSoup\s*\([^)]*['\"]lxml['\"]", re.DOTALL)
-
 
 def _normalize_package_name(name: str) -> str:
     return name.lower().replace("_", "-")
+
+
+class RequirementParseError(ValueError):
+    """Raised when requirements.txt includes cannot be resolved safely."""
 
 
 def python_import_roots(path: Path) -> set[str]:
@@ -48,20 +50,84 @@ def python_import_roots(path: Path) -> set[str]:
     return imports
 
 
-def declared_requirements(requirements_path: Path) -> set[str]:
+def _requirement_include_path(requirements_path: Path, include_path: str) -> Path:
+    include = (requirements_path.parent / include_path).resolve()
+    requirements_root = requirements_path.parent.resolve()
+    try:
+        include.relative_to(requirements_root)
+    except ValueError as exc:
+        raise RequirementParseError(f"requirements include escapes skill folder: {include_path}") from exc
+    if not include.exists():
+        raise RequirementParseError(f"requirements include not found: {include_path}")
+    return include
+
+
+def declared_requirements(requirements_path: Path, seen: set[Path] | None = None) -> set[str]:
     """Return normalized package names from a requirements.txt file."""
     if not requirements_path.exists():
         return set()
 
+    resolved_requirements_path = requirements_path.resolve()
+    seen = seen or set()
+    if resolved_requirements_path in seen:
+        return set()
+    seen.add(resolved_requirements_path)
+
     packages: set[str] = set()
     for line in requirements_path.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
-        if not stripped or stripped.startswith("#") or stripped.startswith("-"):
+        if not stripped or stripped.startswith("#"):
             continue
-        name = re.split(r"\s|<|>|=|!|~|;|\[", stripped, maxsplit=1)[0]
+
+        if stripped.startswith("-r ") or stripped.startswith("--requirement "):
+            include_path = stripped.split(maxsplit=1)[1].split(maxsplit=1)[0]
+            packages.update(declared_requirements(_requirement_include_path(requirements_path, include_path), seen))
+            continue
+
+        if stripped.startswith("-"):
+            continue
+
+        # Marker-gated declarations do not satisfy unconditional script imports.
+        if ";" in stripped:
+            continue
+
+        name = re.split(r"\s|<|>|=|!|~|\[", stripped, maxsplit=1)[0]
         if name:
             packages.add(_normalize_package_name(name))
     return packages
+
+
+def _is_beautifulsoup_call(node: ast.Call) -> bool:
+    if isinstance(node.func, ast.Name):
+        return node.func.id == "BeautifulSoup"
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr == "BeautifulSoup"
+    return False
+
+
+def _string_literal_contains_lxml(node: ast.AST) -> bool:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value == "lxml"
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return any(_string_literal_contains_lxml(item) for item in node.elts)
+    return False
+
+
+def beautifulsoup_lxml_dependencies(path: Path) -> set[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return set()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_beautifulsoup_call(node):
+            continue
+        if any(_string_literal_contains_lxml(arg) for arg in node.args[1:]):
+            return {"lxml"}
+        for keyword in node.keywords:
+            if keyword.arg in {"features", "builder"} and _string_literal_contains_lxml(keyword.value):
+                return {"lxml"}
+    return set()
 
 
 def required_script_dependencies(skill_dir: Path) -> set[str]:
@@ -72,15 +138,13 @@ def required_script_dependencies(skill_dir: Path) -> set[str]:
 
     requirements: set[str] = set()
     for script in sorted(scripts_dir.rglob("*.py")):
-        script_text = script.read_text(encoding="utf-8")
         for import_root in python_import_roots(script):
             if import_root in LOCAL_SCRIPT_IMPORT_ROOTS:
                 continue
             requirement = IMPORT_TO_REQUIREMENT.get(import_root)
             if requirement:
                 requirements.add(requirement)
-        if BEAUTIFULSOUP_LXML_RE.search(script_text):
-            requirements.add("lxml")
+        requirements.update(beautifulsoup_lxml_dependencies(script))
     return requirements
 
 
@@ -110,7 +174,11 @@ def validate_script_dependencies(
             )
         ]
 
-    declared = declared_requirements(requirements_path)
+    try:
+        declared = declared_requirements(requirements_path)
+    except RequirementParseError as exc:
+        return [error(f"{rel_requirements_path} has invalid requirements include: {exc}")]
+
     missing = sorted(
         requirement
         for requirement in required

--- a/scripts/skill_dependency_checks.py
+++ b/scripts/skill_dependency_checks.py
@@ -1,0 +1,121 @@
+"""Validate machine-readable dependency metadata for skill helper scripts."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+IMPORT_TO_REQUIREMENT = {
+    "PIL": "Pillow",
+    "anthropic": "anthropic",
+    "bs4": "beautifulsoup4",
+    "pilmoji": "pilmoji",
+    "requests": "requests",
+    "yaml": "PyYAML",
+}
+
+LOCAL_SCRIPT_IMPORT_ROOTS = {
+    "scripts",
+}
+
+
+def _normalize_package_name(name: str) -> str:
+    return name.lower().replace("_", "-")
+
+
+def python_import_roots(path: Path) -> set[str]:
+    """Return top-level import names used by one Python source file."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return set()
+
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                if root:
+                    imports.add(root)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            root = node.module.split(".", 1)[0]
+            if root:
+                imports.add(root)
+    return imports
+
+
+def declared_requirements(requirements_path: Path) -> set[str]:
+    """Return normalized package names from a requirements.txt file."""
+    if not requirements_path.exists():
+        return set()
+
+    packages: set[str] = set()
+    for line in requirements_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("-"):
+            continue
+        name = re.split(r"\s|<|>|=|!|~|;|\[", stripped, maxsplit=1)[0]
+        if name:
+            packages.add(_normalize_package_name(name))
+    return packages
+
+
+def required_script_dependencies(skill_dir: Path) -> set[str]:
+    """Infer third-party package requirements for Python helper scripts."""
+    scripts_dir = skill_dir / "scripts"
+    if not scripts_dir.exists():
+        return set()
+
+    requirements: set[str] = set()
+    for script in sorted(scripts_dir.rglob("*.py")):
+        for import_root in python_import_roots(script):
+            if import_root in LOCAL_SCRIPT_IMPORT_ROOTS:
+                continue
+            requirement = IMPORT_TO_REQUIREMENT.get(import_root)
+            if requirement:
+                requirements.add(requirement)
+    return requirements
+
+
+def validate_script_dependencies(
+    *,
+    root: Path,
+    entry_path: str,
+    entry_format: str,
+    error,
+) -> list[str]:
+    if entry_format != "directory":
+        return []
+
+    skill_dir = (root / entry_path).parent
+    required = required_script_dependencies(skill_dir)
+    if not required:
+        return []
+
+    requirements_path = skill_dir / "requirements.txt"
+    rel_requirements_path = requirements_path.relative_to(root)
+    if not requirements_path.exists():
+        required_list = ", ".join(sorted(required))
+        return [
+            error(
+                f"{entry_path} imports third-party script packages but is missing "
+                f"{rel_requirements_path}: {required_list}"
+            )
+        ]
+
+    declared = declared_requirements(requirements_path)
+    missing = sorted(
+        requirement
+        for requirement in required
+        if _normalize_package_name(requirement) not in declared
+    )
+    if missing:
+        return [
+            error(
+                f"{rel_requirements_path} is missing script package declaration(s): "
+                + ", ".join(missing)
+            )
+        ]
+    return []

--- a/scripts/skill_dependency_checks.py
+++ b/scripts/skill_dependency_checks.py
@@ -50,9 +50,8 @@ def python_import_roots(path: Path) -> set[str]:
     return imports
 
 
-def _requirement_include_path(requirements_path: Path, include_path: str) -> Path:
+def _requirement_include_path(requirements_path: Path, include_path: str, requirements_root: Path) -> Path:
     include = (requirements_path.parent / include_path).resolve()
-    requirements_root = requirements_path.parent.resolve()
     try:
         include.relative_to(requirements_root)
     except ValueError as exc:
@@ -62,12 +61,31 @@ def _requirement_include_path(requirements_path: Path, include_path: str) -> Pat
     return include
 
 
-def declared_requirements(requirements_path: Path, seen: set[Path] | None = None) -> set[str]:
+def _requirement_include_value(line: str) -> str | None:
+    if line.startswith("--requirement="):
+        return line.split("=", 1)[1].split(maxsplit=1)[0]
+    if line.startswith("--requirement "):
+        return line.split(maxsplit=1)[1].split(maxsplit=1)[0]
+    if line == "-r" or line == "--requirement":
+        raise RequirementParseError(f"requirements include missing file: {line}")
+    if line.startswith("-r "):
+        return line.split(maxsplit=1)[1].split(maxsplit=1)[0]
+    if line.startswith("-r"):
+        return line[2:].split(maxsplit=1)[0]
+    return None
+
+
+def declared_requirements(
+    requirements_path: Path,
+    seen: set[Path] | None = None,
+    requirements_root: Path | None = None,
+) -> set[str]:
     """Return normalized package names from a requirements.txt file."""
     if not requirements_path.exists():
         return set()
 
     resolved_requirements_path = requirements_path.resolve()
+    requirements_root = requirements_root or resolved_requirements_path.parent
     seen = seen or set()
     if resolved_requirements_path in seen:
         return set()
@@ -79,9 +97,15 @@ def declared_requirements(requirements_path: Path, seen: set[Path] | None = None
         if not stripped or stripped.startswith("#"):
             continue
 
-        if stripped.startswith("-r ") or stripped.startswith("--requirement "):
-            include_path = stripped.split(maxsplit=1)[1].split(maxsplit=1)[0]
-            packages.update(declared_requirements(_requirement_include_path(requirements_path, include_path), seen))
+        include_path = _requirement_include_value(stripped)
+        if include_path is not None:
+            packages.update(
+                declared_requirements(
+                    _requirement_include_path(requirements_path, include_path, requirements_root),
+                    seen,
+                    requirements_root,
+                )
+            )
             continue
 
         if stripped.startswith("-"):
@@ -105,11 +129,11 @@ def _is_beautifulsoup_call(node: ast.Call) -> bool:
     return False
 
 
-def _string_literal_contains_lxml(node: ast.AST) -> bool:
+def _string_literal_requires_lxml(node: ast.AST) -> bool:
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
-        return node.value == "lxml"
+        return node.value in {"lxml", "lxml-xml", "xml"}
     if isinstance(node, (ast.List, ast.Tuple)):
-        return any(_string_literal_contains_lxml(item) for item in node.elts)
+        return any(_string_literal_requires_lxml(item) for item in node.elts)
     return False
 
 
@@ -122,10 +146,10 @@ def beautifulsoup_lxml_dependencies(path: Path) -> set[str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call) or not _is_beautifulsoup_call(node):
             continue
-        if any(_string_literal_contains_lxml(arg) for arg in node.args[1:]):
+        if any(_string_literal_requires_lxml(arg) for arg in node.args[1:]):
             return {"lxml"}
         for keyword in node.keywords:
-            if keyword.arg in {"features", "builder"} and _string_literal_contains_lxml(keyword.value):
+            if keyword.arg in {"features", "builder"} and _string_literal_requires_lxml(keyword.value):
                 return {"lxml"}
     return set()
 

--- a/scripts/skill_dependency_checks.py
+++ b/scripts/skill_dependency_checks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import re
+import shlex
 from pathlib import Path
 
 
@@ -58,20 +59,88 @@ def _requirement_include_path(requirements_path: Path, include_path: str, requir
         raise RequirementParseError(f"requirements include escapes skill folder: {include_path}") from exc
     if not include.exists():
         raise RequirementParseError(f"requirements include not found: {include_path}")
+    if not include.is_file():
+        raise RequirementParseError(f"requirements include is not a file: {include_path}")
     return include
 
 
+def _strip_inline_comment(line: str) -> str:
+    in_single_quote = False
+    in_double_quote = False
+    escaped = False
+    for index, char in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+            continue
+        if char == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+            continue
+        if (
+            char == "#"
+            and not in_single_quote
+            and not in_double_quote
+            and (index == 0 or line[index - 1].isspace())
+        ):
+            return line[:index].rstrip()
+    return line
+
+
+def _requirement_tokens(line: str) -> list[str]:
+    try:
+        return shlex.split(line, comments=True)
+    except ValueError as exc:
+        raise RequirementParseError(f"invalid requirements line: {line}") from exc
+
+
 def _requirement_include_value(line: str) -> str | None:
-    if line.startswith("--requirement="):
-        return line.split("=", 1)[1].split(maxsplit=1)[0]
-    if line.startswith("--requirement "):
-        return line.split(maxsplit=1)[1].split(maxsplit=1)[0]
-    if line == "-r" or line == "--requirement":
-        raise RequirementParseError(f"requirements include missing file: {line}")
-    if line.startswith("-r "):
-        return line.split(maxsplit=1)[1].split(maxsplit=1)[0]
-    if line.startswith("-r"):
-        return line[2:].split(maxsplit=1)[0]
+    tokens = _requirement_tokens(line)
+    if not tokens:
+        return None
+
+    option = tokens[0]
+    if option in {"-r", "--requirement"}:
+        if len(tokens) < 2 or not tokens[1]:
+            raise RequirementParseError(f"requirements include missing file: {option}")
+        return tokens[1]
+    if option.startswith("--requirement="):
+        include_path = option.split("=", 1)[1]
+        if not include_path:
+            raise RequirementParseError(f"requirements include missing file: --requirement")
+        return include_path
+    if option.startswith("-r"):
+        include_path = option[2:]
+        if not include_path:
+            raise RequirementParseError(f"requirements include missing file: -r")
+        return include_path
+    return None
+
+
+def _editable_requirement_value(line: str) -> str | None:
+    tokens = _requirement_tokens(line)
+    if not tokens:
+        return None
+
+    option = tokens[0]
+    if option in {"-e", "--editable"}:
+        if len(tokens) < 2 or not tokens[1]:
+            raise RequirementParseError(f"editable requirement missing target: {option}")
+        return tokens[1]
+    if option.startswith("--editable="):
+        editable_path = option.split("=", 1)[1]
+        if not editable_path:
+            raise RequirementParseError("editable requirement missing target: --editable")
+        return editable_path
+    if option.startswith("-e"):
+        editable_path = option[2:]
+        if not editable_path:
+            raise RequirementParseError("editable requirement missing target: -e")
+        return editable_path
     return None
 
 
@@ -93,7 +162,7 @@ def declared_requirements(
 
     packages: set[str] = set()
     for line in requirements_path.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
+        stripped = _strip_inline_comment(line.strip()).strip()
         if not stripped or stripped.startswith("#"):
             continue
 
@@ -108,11 +177,19 @@ def declared_requirements(
             )
             continue
 
+        editable_path = _editable_requirement_value(stripped)
+        if editable_path is not None:
+            raise RequirementParseError(f"editable requirements are not supported: {editable_path}")
+
         if stripped.startswith("-"):
             continue
 
-        # Marker-gated declarations do not satisfy unconditional script imports.
         if ";" in stripped:
+            _, marker_text = stripped.split(";", 1)
+            if not marker_text.strip():
+                raise RequirementParseError(f"empty environment marker: {stripped}")
+            # Script imports are unconditional, so marker-gated declarations do
+            # not prove the package will be available at runtime.
             continue
 
         name = re.split(r"\s|<|>|=|!|~|\[", stripped, maxsplit=1)[0]
@@ -129,11 +206,47 @@ def _is_beautifulsoup_call(node: ast.Call) -> bool:
     return False
 
 
-def _string_literal_requires_lxml(node: ast.AST) -> bool:
+def _assigned_expressions(tree: ast.AST) -> dict[str, list[ast.AST]]:
+    assignments: dict[str, list[ast.AST]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assignments.setdefault(target.id, []).append(node.value)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.value is not None
+        ):
+            assignments.setdefault(node.target.id, []).append(node.value)
+        elif isinstance(node, ast.NamedExpr) and isinstance(node.target, ast.Name):
+            assignments.setdefault(node.target.id, []).append(node.value)
+    return assignments
+
+
+def _string_literal_requires_lxml(
+    node: ast.AST,
+    assignments: dict[str, list[ast.AST]],
+    seen_names: set[str] | None = None,
+) -> bool:
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value in {"lxml", "lxml-xml", "xml"}
-    if isinstance(node, (ast.List, ast.Tuple)):
-        return any(_string_literal_requires_lxml(item) for item in node.elts)
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return any(
+            _string_literal_requires_lxml(item, assignments, seen_names) for item in node.elts
+        )
+    if isinstance(node, ast.Name):
+        seen_names = seen_names or set()
+        if node.id in seen_names:
+            return False
+        return any(
+            _string_literal_requires_lxml(value, assignments, seen_names | {node.id})
+            for value in assignments.get(node.id, [])
+        )
+    if isinstance(node, ast.IfExp):
+        return _string_literal_requires_lxml(
+            node.body, assignments, seen_names
+        ) or _string_literal_requires_lxml(node.orelse, assignments, seen_names)
     return False
 
 
@@ -143,13 +256,17 @@ def beautifulsoup_lxml_dependencies(path: Path) -> set[str]:
     except SyntaxError:
         return set()
 
+    assignments = _assigned_expressions(tree)
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call) or not _is_beautifulsoup_call(node):
             continue
-        if any(_string_literal_requires_lxml(arg) for arg in node.args[1:]):
+        if any(_string_literal_requires_lxml(arg, assignments) for arg in node.args[1:]):
             return {"lxml"}
         for keyword in node.keywords:
-            if keyword.arg in {"features", "builder"} and _string_literal_requires_lxml(keyword.value):
+            if keyword.arg in {"features", "builder"} and _string_literal_requires_lxml(
+                keyword.value,
+                assignments,
+            ):
                 return {"lxml"}
     return set()
 

--- a/scripts/skill_dependency_checks.py
+++ b/scripts/skill_dependency_checks.py
@@ -20,6 +20,8 @@ LOCAL_SCRIPT_IMPORT_ROOTS = {
     "scripts",
 }
 
+BEAUTIFULSOUP_LXML_RE = re.compile(r"BeautifulSoup\s*\([^)]*['\"]lxml['\"]", re.DOTALL)
+
 
 def _normalize_package_name(name: str) -> str:
     return name.lower().replace("_", "-")
@@ -70,12 +72,15 @@ def required_script_dependencies(skill_dir: Path) -> set[str]:
 
     requirements: set[str] = set()
     for script in sorted(scripts_dir.rglob("*.py")):
+        script_text = script.read_text(encoding="utf-8")
         for import_root in python_import_roots(script):
             if import_root in LOCAL_SCRIPT_IMPORT_ROOTS:
                 continue
             requirement = IMPORT_TO_REQUIREMENT.get(import_root)
             if requirement:
                 requirements.add(requirement)
+        if BEAUTIFULSOUP_LXML_RE.search(script_text):
+            requirements.add("lxml")
     return requirements
 
 

--- a/scripts/skill_dependency_checks.py
+++ b/scripts/skill_dependency_checks.py
@@ -21,6 +21,24 @@ LOCAL_SCRIPT_IMPORT_ROOTS = {
     "scripts",
 }
 
+BARE_URL_REQUIREMENT_PREFIXES = (
+    "git+",
+    "hg+",
+    "svn+",
+    "bzr+",
+    "http://",
+    "https://",
+    "file://",
+)
+
+BEAUTIFULSOUP_PARSER_REQUIREMENTS = {
+    "lxml": "lxml",
+    "lxml-xml": "lxml",
+    "xml": "lxml",
+    "html5": "html5lib",
+    "html5lib": "html5lib",
+}
+
 
 def _normalize_package_name(name: str) -> str:
     return name.lower().replace("_", "-")
@@ -44,7 +62,7 @@ def python_import_roots(path: Path) -> set[str]:
                 root = alias.name.split(".", 1)[0]
                 if root:
                     imports.add(root)
-        elif isinstance(node, ast.ImportFrom) and node.module:
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
             root = node.module.split(".", 1)[0]
             if root:
                 imports.add(root)
@@ -144,6 +162,21 @@ def _editable_requirement_value(line: str) -> str | None:
     return None
 
 
+def _bare_url_requirement_name(line: str) -> str | None:
+    if not line.startswith(BARE_URL_REQUIREMENT_PREFIXES):
+        return None
+
+    fragment = line.split("#", 1)[1] if "#" in line else ""
+    for part in fragment.split("&"):
+        if not part.startswith("egg="):
+            continue
+        name = re.split(r"\s|<|>|=|!|~|\[", part.split("=", 1)[1].strip(), maxsplit=1)[0]
+        if name:
+            return _normalize_package_name(name)
+        break
+    raise RequirementParseError(f"bare URL requirements must include #egg=<package>: {line}")
+
+
 def declared_requirements(
     requirements_path: Path,
     seen: set[Path] | None = None,
@@ -192,15 +225,31 @@ def declared_requirements(
             # not prove the package will be available at runtime.
             continue
 
+        url_requirement_name = _bare_url_requirement_name(stripped)
+        if url_requirement_name is not None:
+            packages.add(url_requirement_name)
+            continue
+
         name = re.split(r"\s|<|>|=|!|~|\[", stripped, maxsplit=1)[0]
         if name:
             packages.add(_normalize_package_name(name))
     return packages
 
 
-def _is_beautifulsoup_call(node: ast.Call) -> bool:
+def _beautifulsoup_call_names(tree: ast.AST) -> set[str]:
+    names = {"BeautifulSoup"}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.level != 0 or node.module != "bs4":
+            continue
+        for alias in node.names:
+            if alias.name == "BeautifulSoup":
+                names.add(alias.asname or alias.name)
+    return names
+
+
+def _is_beautifulsoup_call(node: ast.Call, call_names: set[str]) -> bool:
     if isinstance(node.func, ast.Name):
-        return node.func.id == "BeautifulSoup"
+        return node.func.id in call_names
     if isinstance(node.func, ast.Attribute):
         return node.func.attr == "BeautifulSoup"
     return False
@@ -224,51 +273,56 @@ def _assigned_expressions(tree: ast.AST) -> dict[str, list[ast.AST]]:
     return assignments
 
 
-def _string_literal_requires_lxml(
+def _string_literal_parser_dependencies(
     node: ast.AST,
     assignments: dict[str, list[ast.AST]],
     seen_names: set[str] | None = None,
-) -> bool:
+) -> set[str]:
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
-        return node.value in {"lxml", "lxml-xml", "xml"}
+        requirement = BEAUTIFULSOUP_PARSER_REQUIREMENTS.get(node.value)
+        return {requirement} if requirement else set()
     if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
-        return any(
-            _string_literal_requires_lxml(item, assignments, seen_names) for item in node.elts
-        )
+        requirements: set[str] = set()
+        for item in node.elts:
+            requirements.update(_string_literal_parser_dependencies(item, assignments, seen_names))
+        return requirements
     if isinstance(node, ast.Name):
         seen_names = seen_names or set()
         if node.id in seen_names:
-            return False
-        return any(
-            _string_literal_requires_lxml(value, assignments, seen_names | {node.id})
-            for value in assignments.get(node.id, [])
-        )
+            return set()
+        requirements = set()
+        for value in assignments.get(node.id, []):
+            requirements.update(
+                _string_literal_parser_dependencies(value, assignments, seen_names | {node.id})
+            )
+        return requirements
     if isinstance(node, ast.IfExp):
-        return _string_literal_requires_lxml(
-            node.body, assignments, seen_names
-        ) or _string_literal_requires_lxml(node.orelse, assignments, seen_names)
-    return False
+        return _string_literal_parser_dependencies(
+            node.body,
+            assignments,
+            seen_names,
+        ) | _string_literal_parser_dependencies(node.orelse, assignments, seen_names)
+    return set()
 
 
-def beautifulsoup_lxml_dependencies(path: Path) -> set[str]:
+def beautifulsoup_parser_dependencies(path: Path) -> set[str]:
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except SyntaxError:
         return set()
 
     assignments = _assigned_expressions(tree)
+    call_names = _beautifulsoup_call_names(tree)
+    dependencies: set[str] = set()
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not _is_beautifulsoup_call(node):
+        if not isinstance(node, ast.Call) or not _is_beautifulsoup_call(node, call_names):
             continue
-        if any(_string_literal_requires_lxml(arg, assignments) for arg in node.args[1:]):
-            return {"lxml"}
+        for arg in node.args[1:]:
+            dependencies.update(_string_literal_parser_dependencies(arg, assignments))
         for keyword in node.keywords:
-            if keyword.arg in {"features", "builder"} and _string_literal_requires_lxml(
-                keyword.value,
-                assignments,
-            ):
-                return {"lxml"}
-    return set()
+            if keyword.arg in {"features", "builder"}:
+                dependencies.update(_string_literal_parser_dependencies(keyword.value, assignments))
+    return dependencies
 
 
 def required_script_dependencies(skill_dir: Path) -> set[str]:
@@ -285,7 +339,7 @@ def required_script_dependencies(skill_dir: Path) -> set[str]:
             requirement = IMPORT_TO_REQUIREMENT.get(import_root)
             if requirement:
                 requirements.add(requirement)
-        requirements.update(beautifulsoup_lxml_dependencies(script))
+        requirements.update(beautifulsoup_parser_dependencies(script))
     return requirements
 
 

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -22,6 +22,7 @@ from skill_artifact_checks import (
     skill_markdown_body,
     unresolved_placeholder_tokens,
 )
+from skill_dependency_checks import validate_script_dependencies
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -490,6 +491,15 @@ def validate_entries(entries: list[SkillEntry]) -> list[str]:
                 messages.append(error(f"{entry.path} references unsafe support path {ref.ref}: {ref.unsafe_reason}"))
             elif not ref.target.exists():
                 messages.append(error(f"{entry.path} references missing support file: {ref.ref}"))
+
+        messages.extend(
+            validate_script_dependencies(
+                root=ROOT,
+                entry_path=entry.path,
+                entry_format=entry.format,
+                error=error,
+            )
+        )
 
         line_count = len(path.read_text(encoding="utf-8").splitlines())
         if line_count > 500:

--- a/skills/skill-creator/requirements.txt
+++ b/skills/skill-creator/requirements.txt
@@ -1,0 +1,2 @@
+anthropic
+PyYAML

--- a/skills/web-asset-generator/requirements.txt
+++ b/skills/web-asset-generator/requirements.txt
@@ -1,0 +1,2 @@
+Pillow
+pilmoji

--- a/skills/xiaohongshu/requirements.txt
+++ b/skills/xiaohongshu/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/tests/test_skill_dependency_checks.py
+++ b/tests/test_skill_dependency_checks.py
@@ -132,6 +132,26 @@ class SkillDependencyChecksTests(unittest.TestCase):
 
             self.assertEqual(self.validate_demo_skill(root), [])
 
+    def test_quoted_requirements_include_file_satisfies_dependency(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            skill_dir = self.write_demo_skill(root, "import requests\n", '-r "base deps.txt"\n')
+            (skill_dir / "base deps.txt").write_text("requests\n", encoding="utf-8")
+
+            self.assertEqual(self.validate_demo_skill(root), [])
+
+    def test_directory_requirements_include_reports_validation_error(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            skill_dir = self.write_demo_skill(root, "import requests\n", "-r includes\n")
+            (skill_dir / "includes").mkdir()
+
+            messages = self.validate_demo_skill(root)
+
+            self.assertEqual(len(messages), 1)
+            self.assertIn("invalid requirements include", messages[0])
+            self.assertIn("requirements include is not a file: includes", messages[0])
+
     def test_nested_requirements_include_is_bounded_by_skill_root(self):
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -152,6 +172,17 @@ class SkillDependencyChecksTests(unittest.TestCase):
 
             self.assertEqual(self.validate_demo_skill(root), [])
 
+    def test_editable_requirements_are_rejected(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(root, "import requests\n", "-e ./local-package\n")
+
+            messages = self.validate_demo_skill(root)
+
+            self.assertEqual(len(messages), 1)
+            self.assertIn("invalid requirements include", messages[0])
+            self.assertIn("editable requirements are not supported", messages[0])
+
     def test_marker_gated_requirement_does_not_satisfy_unconditional_import(self):
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -161,6 +192,20 @@ class SkillDependencyChecksTests(unittest.TestCase):
 
             self.assertEqual(len(messages), 1)
             self.assertIn("missing script package declaration(s): requests", messages[0])
+
+    def test_computed_lxml_parser_usage_requires_lxml_declaration(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(
+                root,
+                "from bs4 import BeautifulSoup\nparser = 'lxml'\nsoup = BeautifulSoup(html, parser)\n",
+                "beautifulsoup4\n",
+            )
+
+            messages = self.validate_demo_skill(root)
+
+            self.assertEqual(len(messages), 1)
+            self.assertIn("missing script package declaration(s): lxml", messages[0])
 
     def test_stdlib_only_scripts_do_not_require_requirements_file(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_skill_dependency_checks.py
+++ b/tests/test_skill_dependency_checks.py
@@ -85,6 +85,31 @@ class SkillDependencyChecksTests(unittest.TestCase):
 
             self.assertEqual(self.validate_demo_skill(root), [])
 
+    def test_lxml_parser_usage_requires_lxml_declaration(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(
+                root,
+                "from bs4 import BeautifulSoup\nsoup = BeautifulSoup(html, \"lxml\")\n",
+                "beautifulsoup4\n",
+            )
+
+            messages = self.validate_demo_skill(root)
+
+            self.assertEqual(len(messages), 1)
+            self.assertIn("missing script package declaration(s): lxml", messages[0])
+
+    def test_lxml_parser_usage_passes_when_declared(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(
+                root,
+                "from bs4 import BeautifulSoup\nsoup = BeautifulSoup(html, 'lxml')\n",
+                "beautifulsoup4\nlxml\n",
+            )
+
+            self.assertEqual(self.validate_demo_skill(root), [])
+
     def test_stdlib_only_scripts_do_not_require_requirements_file(self):
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tests/test_skill_dependency_checks.py
+++ b/tests/test_skill_dependency_checks.py
@@ -90,7 +90,7 @@ class SkillDependencyChecksTests(unittest.TestCase):
             root = Path(temp_dir)
             self.write_demo_skill(
                 root,
-                "from bs4 import BeautifulSoup\nsoup = BeautifulSoup(html, \"lxml\")\n",
+                "from bs4 import BeautifulSoup\nsoup = BeautifulSoup(requests.get(url).text, \"lxml\")\n",
                 "beautifulsoup4\n",
             )
 
@@ -109,6 +109,24 @@ class SkillDependencyChecksTests(unittest.TestCase):
             )
 
             self.assertEqual(self.validate_demo_skill(root), [])
+
+    def test_requirements_include_file_satisfies_dependency(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            skill_dir = self.write_demo_skill(root, "import requests\n", "-r common.txt\n")
+            (skill_dir / "common.txt").write_text("requests\n", encoding="utf-8")
+
+            self.assertEqual(self.validate_demo_skill(root), [])
+
+    def test_marker_gated_requirement_does_not_satisfy_unconditional_import(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(root, "import requests\n", 'requests; python_version < "3.0"\n')
+
+            messages = self.validate_demo_skill(root)
+
+            self.assertEqual(len(messages), 1)
+            self.assertIn("missing script package declaration(s): requests", messages[0])
 
     def test_stdlib_only_scripts_do_not_require_requirements_file(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_skill_dependency_checks.py
+++ b/tests/test_skill_dependency_checks.py
@@ -1,0 +1,97 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPENDENCY_CHECKS_SCRIPT = ROOT / "scripts" / "skill_dependency_checks.py"
+
+
+def load_dependency_checks():
+    spec = importlib.util.spec_from_file_location(
+        "skill_dependency_checks_test",
+        DEPENDENCY_CHECKS_SCRIPT,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+dependency_checks = load_dependency_checks()
+
+
+def format_error(message: str) -> str:
+    return f"ERROR: {message}"
+
+
+class SkillDependencyChecksTests(unittest.TestCase):
+    def write_demo_skill(self, root: Path, script_text: str, requirements_text: str | None = None) -> Path:
+        skill_dir = root / "skills" / "demo-skill"
+        scripts_dir = skill_dir / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: demo-skill\n"
+            "description: Use when testing script dependency validation.\n"
+            "---\n\n"
+            "# Demo Skill\n",
+            encoding="utf-8",
+        )
+        (scripts_dir / "tool.py").write_text(script_text, encoding="utf-8")
+        if requirements_text is not None:
+            (skill_dir / "requirements.txt").write_text(requirements_text, encoding="utf-8")
+        return skill_dir
+
+    def validate_demo_skill(self, root: Path) -> list[str]:
+        return dependency_checks.validate_script_dependencies(
+            root=root,
+            entry_path="skills/demo-skill/SKILL.md",
+            entry_format="directory",
+            error=format_error,
+        )
+
+    def test_missing_requirements_file_reports_third_party_imports(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(root, "import requests\nfrom PIL import Image\nfrom pilmoji import Pilmoji\n")
+
+            messages = self.validate_demo_skill(root)
+
+            self.assertEqual(len(messages), 1)
+            self.assertIn("missing skills/demo-skill/requirements.txt", messages[0])
+            self.assertIn("Pillow", messages[0])
+            self.assertIn("pilmoji", messages[0])
+            self.assertIn("requests", messages[0])
+
+    def test_existing_requirements_file_must_declare_all_detected_packages(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(root, "import requests\nfrom PIL import Image\n", "requests>=2\n")
+
+            messages = self.validate_demo_skill(root)
+
+            self.assertEqual(len(messages), 1)
+            self.assertIn("missing script package declaration(s): Pillow", messages[0])
+
+    def test_declared_requirements_pass_and_local_script_imports_are_ignored(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(
+                root,
+                "from scripts.utils import parse_skill_md\nimport yaml\n",
+                "PyYAML\n",
+            )
+
+            self.assertEqual(self.validate_demo_skill(root), [])
+
+    def test_stdlib_only_scripts_do_not_require_requirements_file(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(root, "import json\nfrom pathlib import Path\n")
+
+            self.assertEqual(self.validate_demo_skill(root), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_dependency_checks.py
+++ b/tests/test_skill_dependency_checks.py
@@ -85,12 +85,33 @@ class SkillDependencyChecksTests(unittest.TestCase):
 
             self.assertEqual(self.validate_demo_skill(root), [])
 
+    def test_relative_imports_are_ignored(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(root, "from .requests import helper\nfrom . import utils\n")
+
+            self.assertEqual(self.validate_demo_skill(root), [])
+
     def test_lxml_parser_usage_requires_lxml_declaration(self):
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             self.write_demo_skill(
                 root,
                 "from bs4 import BeautifulSoup\nsoup = BeautifulSoup(requests.get(url).text, \"lxml\")\n",
+                "beautifulsoup4\n",
+            )
+
+            messages = self.validate_demo_skill(root)
+
+            self.assertEqual(len(messages), 1)
+            self.assertIn("missing script package declaration(s): lxml", messages[0])
+
+    def test_beautifulsoup_alias_lxml_parser_usage_requires_lxml_declaration(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(
+                root,
+                "from bs4 import BeautifulSoup as BS\nsoup = BS(html, \"lxml\")\n",
                 "beautifulsoup4\n",
             )
 
@@ -123,6 +144,21 @@ class SkillDependencyChecksTests(unittest.TestCase):
 
             self.assertEqual(len(messages), 1)
             self.assertIn("missing script package declaration(s): lxml", messages[0])
+
+    def test_html5_parser_usage_requires_html5lib_declaration(self):
+        for parser in ("html5lib", "html5"):
+            with self.subTest(parser=parser), TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                self.write_demo_skill(
+                    root,
+                    f"from bs4 import BeautifulSoup\nsoup = BeautifulSoup(data, features={parser!r})\n",
+                    "beautifulsoup4\n",
+                )
+
+                messages = self.validate_demo_skill(root)
+
+                self.assertEqual(len(messages), 1)
+                self.assertIn("missing script package declaration(s): html5lib", messages[0])
 
     def test_requirements_include_file_satisfies_dependency(self):
         with TemporaryDirectory() as temp_dir:
@@ -182,6 +218,28 @@ class SkillDependencyChecksTests(unittest.TestCase):
             self.assertEqual(len(messages), 1)
             self.assertIn("invalid requirements include", messages[0])
             self.assertIn("editable requirements are not supported", messages[0])
+
+    def test_bare_vcs_requirement_with_egg_satisfies_dependency(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(
+                root,
+                "import requests\n",
+                "git+https://github.com/psf/requests.git#egg=requests\n",
+            )
+
+            self.assertEqual(self.validate_demo_skill(root), [])
+
+    def test_bare_vcs_requirement_without_egg_reports_validation_error(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(root, "import requests\n", "git+https://github.com/psf/requests.git\n")
+
+            messages = self.validate_demo_skill(root)
+
+            self.assertEqual(len(messages), 1)
+            self.assertIn("invalid requirements include", messages[0])
+            self.assertIn("bare URL requirements must include #egg=<package>", messages[0])
 
     def test_marker_gated_requirement_does_not_satisfy_unconditional_import(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_skill_dependency_checks.py
+++ b/tests/test_skill_dependency_checks.py
@@ -110,10 +110,44 @@ class SkillDependencyChecksTests(unittest.TestCase):
 
             self.assertEqual(self.validate_demo_skill(root), [])
 
+    def test_xml_parser_usage_requires_lxml_declaration(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            self.write_demo_skill(
+                root,
+                "from bs4 import BeautifulSoup\nsoup = BeautifulSoup(data, features='xml')\n",
+                "beautifulsoup4\n",
+            )
+
+            messages = self.validate_demo_skill(root)
+
+            self.assertEqual(len(messages), 1)
+            self.assertIn("missing script package declaration(s): lxml", messages[0])
+
     def test_requirements_include_file_satisfies_dependency(self):
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             skill_dir = self.write_demo_skill(root, "import requests\n", "-r common.txt\n")
+            (skill_dir / "common.txt").write_text("requests\n", encoding="utf-8")
+
+            self.assertEqual(self.validate_demo_skill(root), [])
+
+    def test_nested_requirements_include_is_bounded_by_skill_root(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            skill_dir = self.write_demo_skill(root, "import requests\n", "-r requirements/base.txt\n")
+            requirements_dir = skill_dir / "requirements"
+            requirements_dir.mkdir()
+            (requirements_dir / "base.txt").write_text("-r ../common.txt\n", encoding="utf-8")
+            (skill_dir / "common.txt").write_text("requests\n", encoding="utf-8")
+
+            self.assertEqual(self.validate_demo_skill(root), [])
+
+    def test_attached_requirements_include_forms_are_supported(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            skill_dir = self.write_demo_skill(root, "import requests\n", "--requirement=base.txt\n")
+            (skill_dir / "base.txt").write_text("-rcommon.txt\n", encoding="utf-8")
             (skill_dir / "common.txt").write_text("requests\n", encoding="utf-8")
 
             self.assertEqual(self.validate_demo_skill(root), [])


### PR DESCRIPTION
## Summary

Fixes #90.

- add per-skill `requirements.txt` files for script-bearing skills that were missing third-party dependency declarations
- add validation for known third-party Python helper-script dependencies, including import-name mappings such as `PIL -> Pillow`, `bs4 -> beautifulsoup4`, `yaml -> PyYAML`, and BeautifulSoup `lxml` parser usage
- add focused tests for missing requirements files, missing package declarations, local helper imports, stdlib-only scripts, and `lxml` parser detection

## Validation

- `python3 -m pytest tests/test_skill_dependency_checks.py`
- `python3 scripts/validate_skills.py --check`
- `python3 -m pytest`
- `python3 scripts/audit_skill_quality.py`
- `python3 -m compileall scripts skills -q`
- `git diff --check`

## Review Notes

An independent read-only review flagged that `lxml` parser usage was not covered by AST import detection. Follow-up commit `9d46614` adds explicit BeautifulSoup `lxml` parser detection and regression tests.
