### PR TITLE
Document Codex plugin distribution strategy

### DIFF
--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -3,8 +3,9 @@
 Spellbook plugin packaging currently targets Claude Code. Plugins in this
 repository use `.claude-plugin/plugin.json`; this repository does not define a
 Codex plugin manifest. For Codex, distribute skills through direct skill install
-with `install.sh --target codex` or by placing `SKILL.md` under
-`$HOME/.agents/skills/<skill-name>/`.
+with `install.sh --target codex` or a manual catalog install that preserves the
+source layout: copy or symlink directory skills as whole directories, and place
+file skills under `$HOME/.agents/skills/<skill-name>/SKILL.md`.
 
 ## Claude Code Plugin Structure
 

--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -1,6 +1,12 @@
 # Creating Plugins Guide
 
-## Plugin Structure
+Spellbook plugin packaging currently targets Claude Code. Plugins in this
+repository use `.claude-plugin/plugin.json`; this repository does not define a
+Codex plugin manifest. For Codex, distribute skills through direct skill install
+with `install.sh --target codex` or by placing `SKILL.md` under
+`$HOME/.agents/skills/<skill-name>/`.
+
+## Claude Code Plugin Structure
 
 ```
 my-plugin/
@@ -12,7 +18,7 @@ my-plugin/
 └── hooks/               # Optional: Hook configurations
 ```
 
-## plugin.json Format
+## Claude Code plugin.json Format
 
 ```json
 {
@@ -48,10 +54,15 @@ my-plugin/
 
 ## Creating Skills
 
-Plugin packages in this repository currently use file skills under `skills/*.SKILL.md`.
-Use this layout for plugin marketplace compatibility unless the plugin runtime you target documents directory skill support.
+Claude Code plugin packages in this repository currently use file skills under
+`skills/*.SKILL.md`. Use this layout for plugin marketplace compatibility
+unless the plugin runtime you target documents directory skill support.
 
 For the top-level Spellbook catalog installed by `install.sh`, see [Skill Format Policy](./skill-format-policy.md). New catalog skills should generally use the directory layout when they need progressive disclosure, templates, scripts, evals, or other companion files.
+
+Codex does not use a plugin package from this repository today. Codex skills are
+installed directly from the catalog source into `$HOME/.agents/skills`, either
+through `install.sh --target codex` or a manual copy/download of `SKILL.md`.
 
 Plugin skill files use this frontmatter:
 
@@ -106,7 +117,7 @@ tools: ["Read", "Grep", "Glob"]
 Agent behavior and instructions...
 ```
 
-## Testing Locally
+## Testing Claude Code Plugins Locally
 
 ```bash
 # Add your plugin as a local marketplace
@@ -122,7 +133,7 @@ Agent behavior and instructions...
 /plugin uninstall my-plugin
 ```
 
-## Publishing
+## Publishing Claude Code Plugins
 
 1. Push to GitHub
 2. Share the installation command:
@@ -130,3 +141,7 @@ Agent behavior and instructions...
    /plugin marketplace add https://github.com/username/repo
    /plugin install my-plugin
    ```
+
+For Codex users, publish the skill source and document direct installation into
+the current Codex skill target, `$HOME/.agents/skills`. Do not document a Codex
+plugin manifest for this repository until one is actually supported.

--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -62,7 +62,11 @@ For the top-level Spellbook catalog installed by `install.sh`, see [Skill Format
 
 Codex does not use a plugin package from this repository today. Codex skills are
 installed directly from the catalog source into `$HOME/.agents/skills`, either
-through `install.sh --target codex` or a manual copy/download of `SKILL.md`.
+through `install.sh --target codex` or a manual catalog install. For directory
+skills, copy or symlink the whole `skills/<name>/` directory so companion
+`references/`, `scripts/`, `assets/`, and other support files stay available.
+For file skills, install `skills/<name>.SKILL.md` as
+`$HOME/.agents/skills/<name>/SKILL.md`.
 
 Plugin skill files use this frontmatter:
 

--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -147,6 +147,7 @@ Agent behavior and instructions...
    /plugin install my-plugin
    ```
 
-For Codex users, publish the skill source and document direct installation into
-the current Codex skill target, `$HOME/.agents/skills`. Do not document a Codex
-plugin manifest for this repository until one is actually supported.
+For Codex users, direct installation into `$HOME/.agents/skills` is only a
+local raw-catalog workaround for testing or internal use. Do not present it as
+the Codex publishing path. Document Codex plugin publishing only after this
+repository adds a supported Codex plugin package and manifest.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,9 +29,12 @@ Codex user-level skills follow the current OpenAI-documented path,
 `$HOME/.agents/skills`. Older Spellbook releases used `~/.codex/skills`; run
 the current installer again to refresh symlinks into the supported location.
 
-## Installing Plugins
+## Installing Claude Code Plugins
 
-Plugins are currently Claude Code-specific because they use the `.claude-plugin` manifest format.
+Plugins are currently Claude Code-specific because they use the `.claude-plugin`
+manifest format. Codex plugin packaging is not supported by this repository
+today; install Codex skills directly with `install.sh --target codex` or into
+`$HOME/.agents/skills`.
 
 ### Method 1: Via Plugin Marketplace (Recommended)
 
@@ -60,7 +63,10 @@ git clone https://github.com/majiayu000/spellbook.git
 
 ### Skills
 
-For repository-local installation, prefer `install.sh --skills <skill-name>` because it supports both source layouts and both runtime targets:
+For repository-local installation, prefer
+`install.sh --target <target> --skills <skill-name>` because it supports both
+source layouts and both runtime targets. This is the Codex distribution path for
+Spellbook skills today: direct skill install, not plugin manifest packaging.
 
 - Directory skills: `skills/<skill-name>/SKILL.md`
 - File skills: `skills/<skill-name>.SKILL.md`
@@ -122,13 +128,13 @@ curl -o ./CLAUDE.md \
 After installation, verify components are loaded:
 
 ```bash
-# Check installed plugins
+# Check installed Claude Code plugins
 /plugin list
 
 # Ask Claude about available skills
 "What skills do you have available?"
 
-# Codex
+# Codex direct skill install
 # Restart Codex so it reloads ~/.agents/skills.
 ```
 

--- a/docs/runtime-targets.md
+++ b/docs/runtime-targets.md
@@ -4,13 +4,19 @@ Spellbook is a source library for reusable agent skills. The same skill source c
 
 ## Supported Targets
 
-| Target | Skills | Agents | Notes |
-|--------|--------|--------|-------|
-| Claude Code | `~/.claude/skills` | `~/.claude/agents` | Full existing support, including Claude Code plugins |
-| Codex | `~/.agents/skills` | Not installed | Skills are installed as `SKILL.md`; restart Codex after install |
+| Target | Skills | Agents | Plugin Packaging | Notes |
+|--------|--------|--------|------------------|-------|
+| Claude Code | `~/.claude/skills` | `~/.claude/agents` | `.claude-plugin` | Full existing support, including Claude Code plugins |
+| Codex | `~/.agents/skills` | Not installed | Not supported in this repository | Skills are installed directly as `SKILL.md`; restart Codex after install |
 
 Older Spellbook releases installed Codex skills under `~/.codex/skills`. New
 installs use the current Codex user-level skill path, `$HOME/.agents/skills`.
+
+## Plugin Packaging
+
+Claude Code plugins in this repository use `.claude-plugin` manifests. Codex
+distribution is direct skill install to the current Codex skill target for now;
+there is no Codex plugin manifest format implemented in this repository.
 
 ## Install Examples
 


### PR DESCRIPTION
## Summary

Fixes #88.

- clarify that Spellbook plugin packaging currently targets Claude Code via `.claude-plugin` manifests
- document Codex distribution as direct skill install through `install.sh --target codex` or `$HOME/.agents/skills`
- align plugin terminology across installation, runtime target, and plugin creation docs

## Validation

- `python3 scripts/validate_skills.py --check`
- `git diff --check`
- focused `rg` check for `.codex-plugin`, `.claude-plugin`, and direct skill install wording across the three touched docs
