### PR TITLE
Fix Codex path and count drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Use this section for notable changes after the latest dated snapshot.
 ### Changed
 
 - Corrected current installable skill count references to match the validator
-  output of 82 skills.
+  output of 85 skills.
 - Updated the installable skill count from 81 to 82.
 - Updated the installable skill count from 80 to 81.
 - Tightened the `threads` skill merge gate so GitHub queue work must check

--- a/docs/skill-layering-architecture.md
+++ b/docs/skill-layering-architecture.md
@@ -223,7 +223,7 @@ safe update and uninstall.
   ],
   "artifacts": [
     {
-      "path": "~/.codex/skills/threads/SKILL.md",
+      "path": "~/.agents/skills/threads/SKILL.md",
       "source": ".spellbook/generated/codex/skills/threads/SKILL.md",
       "owner": "spellbook",
       "target": "skills/threads/SKILL.md",


### PR DESCRIPTION
## Summary
- Update the active Codex skill path example to the current user-level skill directory.
- Bring the changelog's current validator count reference to 85 skills.

Closes #87

## Verification
- python3 scripts/validate_skills.py --check
- git diff --check
- rg -n "~/.codex/skills" docs README.md README_CN.md CHANGELOG.md install.sh
- rg -n "output of [0-9]+ skills|[0-9]+ Cross-Runtime Skills|[0-9]+ 个跨 Runtime Skills|skills-[0-9]+|[0-9]+ Skills \| 7 Agents|Total installable skills: [0-9]+" README.md README_CN.md CHANGELOG.md install.sh docs/skill-registry.md