### PR TITLE
chore: update LICENSE copyright year to 2025-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 majiayu000
+Copyright (c) 2025-2026 majiayu000
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What

Update the MIT `LICENSE` copyright year from `2025` to `2025-2026`.

> Copyright (c) 2025-2026 majiayu000

## Why

`LICENSE:3` has shown `Copyright (c) 2025` since the repository was created (`3d727bb`). The project is actively maintained in 2026 (`main` HEAD: `99433f2`), so the year was stale.

Closes #98

## Scope

Single file, single line on `main`:

```diff
-Copyright (c) 2025 majiayu000
+Copyright (c) 2025-2026 majiayu000
```

## Out of scope (tracked in #98)

The `codex/add-agent-workflow-skill` branch (#93) reintroduces "Claude Arsenal" in `scripts/audit_skill_quality.py:2` and `docs/skill-quality-playbook.md:3`, which `main` already fixed in `f726681`. That should be re-synced as part of #93, not here.

## Verification

- `git diff LICENSE` shows only the year change (1 line).
- Built on the latest `origin/main`.