### PR TITLE
docs(changelog): archive Unreleased as 2026-06-19 snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Use this section for notable changes after the latest dated snapshot.
 
 ### Added
 
+<!-- none yet -->
+
+### Changed
+
+<!-- none yet -->
+
+## [2026-06-19]
+
+### Added
+
 - Added the `skill-audit` skill based on Anthropic's Claude Code skills
   lessons, covering skill taxonomy, trigger descriptions, progressive
   disclosure, setup, memory, scripts, hooks, distribution, and measurement.


### PR DESCRIPTION
## What

Archive the accumulated `[Unreleased]` entries as a new `## [2026-06-19]` dated snapshot. The `[Unreleased]` section is reset to empty placeholders.

## Why

The latest dated snapshot was `2026-06-03`, but `main` had advanced to commit `99433f2` (2026-06-19) with notable user-facing changes sitting in `[Unreleased]`. Per the file's own rule ("entries are grouped by dated snapshots"), these should be archived under a dated heading.

## Changes

Moved 4 `### Added` and 9 `### Changed` entries verbatim from `[Unreleased]` into a new `## [2026-06-19]` section. **No entry text is changed** — only the heading. Diff is +10 lines (the new heading + two `<!-- none yet -->` placeholders).

Includes: `skill-audit` / `gemma4-local-deploy` / `architecture-foundation` skills, release-status sections, skill-count corrections (→85), `threads` merge-gate tightening, Gemma 4 Ollama route + long-context + QAT docs, Validate workflow action upgrades (`checkout@v6`, `setup-python@v6`), and Discussions → issue-template paths.

## Verification (this session)

`grep "^## \[" CHANGELOG.md` confirms ordering: `[Unreleased]` (empty) → `[2026-06-19]` (archived) → `[2026-06-03]` → …

🤖 Generated with [Claude Code](https://claude.com/claude-code)