### PR TITLE
[codex] Tighten codex-retrospective evidence preflight

### DIFF
--- a/skills/codex-retrospective/SKILL.md
+++ b/skills/codex-retrospective/SKILL.md
@@ -40,7 +40,20 @@ You specify the time window or focus area:
 - "The three big auth + payments threads from last month"
 - "All sessions involving the new Go service"
 
-### 2. History Analysis (The Skill Guides Codex)
+### 2. Evidence Collection Preflight
+
+Before proposing any AGENTS.md update or tiny skill, Codex must build a small
+evidence inventory:
+
+- Scope: repo/project, time window, and focus area.
+- Sources checked: current AGENTS.md, relevant existing skills, repo docs, Memories/Chronicle, and local Codex session files when available.
+- Evidence handles: session IDs, memory IDs, file paths, PR/issue numbers, or dated incidents that can be checked later.
+- Runtime availability: distinguish "skill exists in source" from "skill is installed and triggerable in the active runtime" when that matters.
+- No-change path: if evidence is weak, stop with a concise "no high-confidence change" result instead of manufacturing proposals.
+
+Every proposed update must map back to at least one concrete evidence handle.
+
+### 3. History Analysis (The Skill Guides Codex)
 
 Codex is instructed to look for:
 - Recurring mistakes or inefficient patterns
@@ -49,17 +62,18 @@ Codex is instructed to look for:
 - Successful patterns worth encoding so they happen by default
 - Opportunities to extract tiny, reusable skills
 
-### 3. Output — Strict Format
+### 4. Output — Strict Format
 
 The skill forces Codex to produce output in this order:
 
+0. **Evidence Inventory** (scope, sources checked, and concrete handles)
 1. **Retrospective Summary** (short, evidence-based)
 2. **Proposed AGENTS.md Updates** (exact diff or append text only)
 3. **New or Refined Minimal Skills** (at most 1-2 tiny ones, full SKILL.md with frontmatter)
 4. **Rationale + Evidence** (which sessions/patterns drove each proposal)
 5. **Application Plan** (how to safely apply the changes)
 
-### 4. Human Gate + Application
+### 5. Human Gate + Application
 
 You review. The skill then helps you apply the minimal changes cleanly (never blindly overwriting large sections of AGENTS.md).
 
@@ -80,6 +94,7 @@ A good monthly ritual for serious users:
 - Never propose large rewrites of AGENTS.md.
 - Never create big new skills. Tiny, focused, high-ROI only.
 - Every proposal must reference concrete history ("In the payment retry thread on May 3rd and the similar incident on May 18th...").
+- Do not propose changes until the evidence inventory exists and each proposal maps to a concrete handle.
 - If nothing high-confidence was found, say so clearly instead of manufacturing improvements.
 
 ## Gotchas

--- a/skills/codex-retrospective/references/examples/good-retrospective-output.md
+++ b/skills/codex-retrospective/references/examples/good-retrospective-output.md
@@ -2,6 +2,12 @@
 
 **Window:** Last 18 days, focused on the new Go service work.
 
+## Evidence Inventory
+
+- Scope: new Go service work, last 18 days.
+- Sources checked: current AGENTS.md, service-specific skills, local session summaries, and three Codex session files.
+- Evidence handles: sessions from May 4, May 9, May 12, and May 15; AGENTS.md "Core Implementation Principles"; service money-movement skill.
+
 ## Retrospective Summary
 
 - Repeatedly started implementation before fully clarifying the exact failure modes the user cared about most (happened in at least 3 sessions).

--- a/skills/codex-retrospective/references/retrospective-prompt.md
+++ b/skills/codex-retrospective/references/retrospective-prompt.md
@@ -17,12 +17,29 @@ You are performing a high-signal retrospective on your own recent usage history 
 3. Prefer updating or slightly extending existing rules over adding new ones.
 4. Only extract a new skill if the pattern is genuinely reusable and would have saved significant time/friction in multiple places.
 5. If you cannot find strong evidence for a useful change, say so honestly.
+6. Do not propose changes until you have listed the evidence sources checked and concrete handles for the evidence you rely on.
 
 **Process:**
 
-First, deeply review the relevant session history, any available Memories or Chronicle, and the current AGENTS.md + skills.
+First, define the scope and build an evidence inventory:
+
+- Scope: repo/project, time window, and focus area.
+- Sources checked: current AGENTS.md, relevant existing skills, repo docs, Memories/Chronicle, and local Codex session files when available.
+- Evidence handles: session IDs, memory IDs, file paths, PR/issue numbers, or dated incidents that can be checked later.
+- Runtime availability: distinguish "skill exists in source" from "skill is installed and triggerable in the active runtime" when that matters.
+
+Then deeply review the relevant session history, any available Memories or Chronicle, and the current AGENTS.md + skills.
 
 Then output **exactly** in this structure:
+
+## 0. Evidence Inventory
+
+- Scope reviewed.
+- Sources checked.
+- Concrete evidence handles used for the proposals.
+- Any source/runtime availability distinctions that matter.
+
+If this section cannot list enough evidence for a high-confidence change, stop after section 1 with a clear no-change recommendation.
 
 ## 1. Retrospective Summary
 
@@ -48,6 +65,7 @@ For each:
 ## 4. Evidence & Rationale
 
 For every proposal above, point to the concrete patterns in history that justify it.
+Map every proposed AGENTS.md update or tiny skill to at least one evidence handle from section 0.
 
 ## 5. Application Recommendation
 


### PR DESCRIPTION
## Summary

- add an evidence collection preflight to `codex-retrospective`
- require source inventories, concrete evidence handles, and proposal-to-evidence mapping before recommending AGENTS.md or skill updates
- update the prompt template and example output to include an Evidence Inventory section

Closes #103

## Validation

- `python3 scripts/validate_skills.py --check`
- `python3 -m pytest`
- `git diff --check`