### PR TITLE
[codex] add scoped agent contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# Spellbook Agent Contract
+
+Spellbook is a cross-runtime skill library, not a prompt dump. Keep this file
+short: path-scoped `AGENTS.md` files carry directory-specific rules.
+
+## Routing
+
+- Search before creating a new skill, script, registry entry, or support file.
+  Prefer `rg`, `rg --files`, and `python3 scripts/validate_skills.py search`.
+- For skill authoring or refactors, read `docs/skill-format-policy.md`,
+  `docs/skill-quality-playbook.md`, and
+  `docs/spellbook-operating-contract.md` before editing.
+- For generated registry or install metadata, change the source of truth and
+  regenerate; do not hand-edit generated outputs.
+- For high-context files such as `AGENTS.md`, `CLAUDE.md`, and skill
+  `SKILL.md` files, keep changes intentional, scoped, and visible in the final
+  summary.
+
+## Scope Rules
+
+- Do exactly the requested change. Do not add opportunistic migrations,
+  rewrites, or broad cleanup.
+- Prefer existing scripts, validators, parsers, and local conventions over new
+  helper code.
+- Do not invent metadata fields, registry fields, runtime targets, install
+  behavior, or API surfaces. No data means blank or blocked.
+- Do not silently swallow validation errors. Fix the root cause or report the
+  blocker.
+- Never commit secrets, tokens, private keys, or credential material.
+
+## Validation
+
+- Skill, registry, install, or README count changes:
+  `python3 scripts/validate_skills.py --check`.
+- Material skill content changes:
+  `python3 scripts/audit_skill_quality.py <skill-name>`.
+- Registry regeneration:
+  `python3 scripts/validate_skills.py --write` followed by
+  `python3 scripts/validate_skills.py --check`.
+- Python script changes: run targeted tests when present; otherwise run
+  `python3 -m py_compile scripts/*.py` plus the relevant workflow command.
+- If verification cannot run in the current environment, report the missing
+  precondition and the exact command to run later.
+
+## Generated Files
+
+These files are generated or derived and should not be manually edited unless
+the generator itself is being repaired:
+
+- `registry/skills.json`
+- `registry/tags.json`
+- `docs/skill-registry.md`
+
+## Decision Defaults
+
+| Situation | Default |
+|---|---|
+| New installable skill | Use `skills/<name>/SKILL.md`. |
+| Small existing file skill | Keep it as `skills/<name>.SKILL.md` unless it needs support files. |
+| Long examples, templates, or references | Move them under the skill's support directories and link from `SKILL.md`. |
+| Repeated manual command | Prefer adding or updating a script after the workflow is proven manually. |
+| Destructive, remote production, publishing, billing, or credential action | Ask before acting unless the user already gave explicit approval. |
+
+## VibeGuard Summary
+
+- L1: Search first before creating anything new.
+- L2: Use snake_case internally; preserve camelCase only at API boundaries.
+- L3: Do not use `Any`-style public APIs or silent exception swallowing.
+- L4: Do not invent undeclared data, fields, APIs, or fallback output.
+- L5: Keep to the requested scope.
+- L6: Route work as execute directly, plan first, or clarify first based on
+  risk and missing inputs.
+- L7: Do not submit keys, force-push, or hide high-context changes.

--- a/registry/AGENTS.md
+++ b/registry/AGENTS.md
@@ -1,0 +1,34 @@
+# Registry Directory Contract
+
+The registry is derived from skill source files and tag overrides. Treat this
+directory as generated metadata unless you are editing a declared source of
+truth.
+
+## Sources Of Truth
+
+| Need | Edit |
+|---|---|
+| Skill name or description | The skill's frontmatter in `skills/` |
+| Manual tag correction | `registry/tag_overrides.yml` |
+| Category, discovery, render, or validation behavior | `scripts/validate_skills.py` |
+| Generated registry payload | Regenerate with `python3 scripts/validate_skills.py --write` |
+
+## Rules
+
+- Do not manually edit `registry/skills.json` or `registry/tags.json`.
+- Do not invent registry fields. Add validator, renderer, docs, and tests for
+  any real schema change.
+- Keep generated output deterministic and sorted so diffs stay reviewable.
+- If `docs/skill-registry.md` is stale, regenerate it through the validator
+  instead of editing it directly.
+
+## Validation
+
+Run after registry source changes:
+
+```bash
+python3 scripts/validate_skills.py --write
+python3 scripts/validate_skills.py --check
+```
+
+If only inspecting registry state, run `python3 scripts/validate_skills.py --check`.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,49 @@
+# Scripts Directory Contract
+
+Scripts are operational entry points for validation, registry generation, and
+quality audits. Prefer small, explicit changes that preserve existing command
+interfaces.
+
+## Before Editing
+
+- Search for an existing parser, renderer, validator, or helper before adding a
+  new one.
+- Inspect tests and callers with `rg <function-or-command>`.
+- For skill metadata behavior, read `scripts/validate_skills.py` before changing
+  generated files.
+
+## Rules
+
+- Do not silently swallow exceptions. Return clear validation errors or fail
+  with a useful message.
+- Do not parse structured files with ad hoc string slicing when an existing
+  parser or standard library parser is available.
+- Preserve deterministic output ordering for generated files.
+- Keep command-line behavior backward compatible unless the user explicitly asks
+  for a breaking change.
+- Avoid public helpers that are only used once.
+- Do not hardcode credentials, local-only absolute paths, or private machine
+  state.
+
+## Validation
+
+- Python syntax check:
+
+```bash
+python3 -m py_compile scripts/*.py
+```
+
+- Skill and registry behavior:
+
+```bash
+python3 scripts/validate_skills.py --check
+```
+
+- Skill quality audit behavior:
+
+```bash
+python3 scripts/audit_skill_quality.py
+```
+
+Run narrower targeted tests when they exist, then the relevant workflow command
+that proves the changed script behavior.

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -1,0 +1,50 @@
+# Skills Directory Contract
+
+This directory contains installable Spellbook skills. A skill should help an
+agent decide when to act, how to act, when to escalate, and how to verify the
+result.
+
+## Before Editing
+
+1. Search for an existing skill first:
+   `python3 scripts/validate_skills.py search <topic>` and `rg <topic> skills`.
+2. Read the relevant policy files:
+   `docs/skill-format-policy.md`, `docs/skill-quality-playbook.md`, and
+   `docs/spellbook-operating-contract.md`.
+3. Inspect nearby skills with the same category or runtime target before adding
+   new conventions.
+
+## Layout
+
+| Case | Layout |
+|---|---|
+| New skill | `skills/<name>/SKILL.md` |
+| Existing tiny self-contained skill | `skills/<name>.SKILL.md` may remain |
+| Skill with scripts, references, templates, assets, agents, or evals | Directory skill |
+
+- Do not convert file skills to directory skills only for cosmetic consistency.
+- When migrating a file skill because it needs support files, use `git mv` and
+  update direct links.
+- Frontmatter `name` must match the install name.
+- Allowed frontmatter keys are defined by `scripts/validate_skills.py`; do not
+  add new keys unless the validator and registry behavior are updated together.
+
+## Skill Content
+
+- Make `SKILL.md` the router, not the whole knowledge base.
+- Put long examples, API tables, prompts, templates, assets, and extended
+  guidance in support directories and load them only when relevant.
+- Every mature workflow skill should include trigger boundaries, gotchas,
+  autonomy boundaries, and done-when checks.
+- Pair prohibitions with concrete alternatives: name the helper, script,
+  reference file, or canonical path to use instead.
+- Do not add tests for statically defined values or removed behavior.
+
+## Validation
+
+- After adding or materially changing a skill, run:
+  `python3 scripts/validate_skills.py --check`.
+- For content-quality changes, also run:
+  `python3 scripts/audit_skill_quality.py <skill-name>`.
+- If registry output is stale, run:
+  `python3 scripts/validate_skills.py --write` and then rerun `--check`.


### PR DESCRIPTION
## Summary
- add a concise root AGENTS.md for repository-level routing and validation
- add scoped AGENTS.md contracts for skills, registry, and scripts
- document generated-file boundaries and concrete validation commands

## Issue
Closes #108

## Validation
- python3 scripts/validate_skills.py --check

Result: Validated 86 installable skills: 0 errors, 0 warnings.