### PR TITLE
fix(threads): harden run-log queue gate evidence

### DIFF
--- a/docs/threads-run-governance-spec.md
+++ b/docs/threads-run-governance-spec.md
@@ -1,0 +1,139 @@
+# Threads Run Governance Spec
+
+## Status
+
+Draft for the `threads` skill governance cleanup. This spec is based on
+`origin/main` at `5ba135e` and the current `skills/threads` directory layout.
+
+## Problem
+
+Recent Codex sessions show that native subagents are being used successfully for
+parallel review, research, and GitHub queue work, but the evidence is hard to
+audit after the fact. The durable run log is optional, the active skill source
+is often implicit, and some fields required by `SKILL.md` are not accepted or
+validated by `append_run_log.py`.
+
+The goal is not to make every small read-only task noisy. The goal is to make
+non-trivial `threads` runs reproducible enough to answer:
+
+- Was a native subagent really spawned?
+- Which lane owned each decision or file scope?
+- Was `origin/main` fresh for the branch or PR?
+- Were GitHub issues, PRs, CI, and review threads checked with current data?
+- Did the run write a compact, private, project-scoped audit record?
+
+## Non-Goals
+
+- Do not replace Codex native subagents with tmux, shell loops, or external
+  orchestration.
+- Do not log raw prompts, private messages, command output dumps, tokens,
+  cookies, or credential material.
+- Do not merge PRs automatically. The `threads` merge gate remains explicit and
+  user-authorized.
+- Do not split `append_run_log.py` in the first cleanup PR. It is approaching
+  the size where a split may be worthwhile, but this tranche should stay
+  localized.
+
+## Contract
+
+### Dispatch Evidence
+
+Any explicit `threads` request that reaches `plan_only`, `execute_direct`,
+`review_only`, or `research_spec` must record a `thread_dispatch_gate`.
+
+When native subagents are available and spawning is required:
+
+- `fallback_mode: none` is valid only with at least one real spawned agent.
+- The coordinator lane does not count as a spawned native thread.
+- Every planned native lane must either have matching spawned evidence or a
+  lane-level `no_spawn_reason`.
+- Completed native agents must be closed after their result is collected.
+
+### Remote State Ownership
+
+`git fetch --prune origin` mutates Git metadata even when it does not alter the
+worktree. For shared repo queues, the coordinator or `verification_owner` owns
+remote refresh and passes a snapshot into read-only lanes. A lane may fetch only
+when it works in an isolated worktree and its lane map says so.
+
+### Run Log Defaults
+
+Durable JSONL logging defaults to `local_jsonl` for:
+
+- GitHub issue or PR queue runs.
+- Multi-lane runs.
+- Runs that may push, comment, mark ready, close, or merge.
+
+Tiny read-only or truly single-agent runs may remain final-report-only, but
+must record `no_log_reason` when a log would otherwise be expected.
+
+### Canonical Fields
+
+`SKILL.md`, `references/run-log.md`, prompt templates, and
+`scripts/append_run_log.py` must use the same canonical field names. `queue_gate`
+is a first-class field because `SKILL.md` requires it before GitHub queue worker
+lanes begin.
+
+The append script should reject unknown enum values for the fields it can check
+cheaply:
+
+- `native_subagents`
+- `spawn_requirement`
+- `data_collection`
+- `outcome`
+- `failure_codes`
+- `remote_refresh.owner_lane`
+- `remote_refresh.policy`
+- `queue_gate.pr_classification[].classification`
+- lane `role`
+- lane `verification_scope`
+
+## First PR Scope
+
+The first implementation PR should:
+
+- Add this spec.
+- Accept `queue_gate` in the run-log allowlist.
+- Add lightweight enum validation for common top-level and lane fields.
+- Require a `remote_refresh` owner and base snapshot when `queue_gate` is
+  logged.
+- Add `--print-path` and `--validate-only` to support installed-skill and CI
+  workflows.
+- Tighten existing log file permissions to `0600` on append.
+- Redact `KEY=value` style secret assignments in free-form strings.
+- Update `run-log.md` to explain installed skill script paths and missing-file
+  safe analysis queries.
+- Update prompt templates so read-only lanes do not own shared remote refresh
+  by default.
+- Add targeted unit tests for the above.
+
+## Follow-Up Issues
+
+1. Require evidence-bearing `single_agent` fallback objects for explicit
+   threads requests after a compatibility window.
+2. Split run-log schema constants out of `append_run_log.py` if the file keeps
+   growing or if multiple tools need the same field contract.
+3. Add a small local analysis helper that scans Codex JSONL and durable
+   threads run logs together, so missing durable records can be found without
+   broad raw greps.
+4. Add deeper shape validation for `queue_ledger`, `remote_closure`,
+   `connector_review`, and `lane_map`.
+
+## Acceptance
+
+The first PR is complete when these commands pass from a branch based on fresh
+`origin/main`:
+
+```bash
+python3 -m unittest tests.test_threads_run_log
+python3 scripts/validate_skills.py --check
+python3 scripts/audit_skill_quality.py threads
+```
+
+The PR body must include:
+
+- `origin/main` SHA used as base.
+- Created GitHub issue numbers.
+- Native subagent ids used for planning or review.
+- Fresh verification command output.
+- Whether durable run-log writing was performed for the PR run.

--- a/skills/threads/SKILL.md
+++ b/skills/threads/SKILL.md
@@ -171,6 +171,7 @@ queue_gate:
 - truth_level:
 - remote_refresh:
     base_ref:
+    owner_lane:
     origin_main_sha:
     local_base_sha:
     stale_base:

--- a/skills/threads/SKILL.md
+++ b/skills/threads/SKILL.md
@@ -10,6 +10,17 @@ Use this skill to turn a broad request into controlled Codex-native subthreads w
 
 Native Codex threads are short-lived parallel work lines inside the Codex workflow. They are not the same as OMX/tmux workers. If native subagent tools are not visible, discover them with tool search. If no native subagent capability is available, produce the thread prompt pack and execution plan instead of pretending threads were launched.
 
+## Quick Path
+
+1. Classify the request: `single_agent`, `plan_only`, `execute_direct`, `review_only`, `research_spec`, or `clarify_first`.
+2. If the user explicitly asked for threads, record `thread_dispatch_gate` and spawn required native lanes before implementation.
+3. For GitHub queues, fetch remote state in the coordinator lane, then write `queue_gate`, `queue_ledger`, and `issue_to_pr_map`.
+4. Write a lane map with file ownership, verification owner, and stop conditions.
+5. Dispatch only bounded native lanes with disjoint writable scopes or read-only roles.
+6. Collect, wait, and close spawned agents; do not count the coordinator as a spawned thread.
+7. Run fresh verification tied to the current head or artifact.
+8. End with a compact final report and `threads_run_log`; write durable JSONL for queue, multi-lane, push, comment, or merge-capable runs.
+
 ## Do Not Use For
 
 Do not use this skill for generic uses of "thread" unless the user explicitly means Codex workflow orchestration:

--- a/skills/threads/references/prompt-patterns.md
+++ b/skills/threads/references/prompt-patterns.md
@@ -23,7 +23,8 @@ Use these templates as raw material. Fill concrete repo paths, PR numbers, issue
 - 记录 active_skill_source：实际加载的 skill 路径和可发现的 source SHA；发现不了就写 unknown，不要猜。
 - queue_gate 必须包含每个 open PR 的分类：merge_ready / review_thread_blocked / ci_failed / conflict_blocked / stale_or_superseded / needs_human_decision。
 - queue_gate 必须包含 truth_level：A=GitHub API/GraphQL/head/check/reviewThreads 全新鲜；B=GraphQL 不可用但 REST 可用，禁止 merge；C=仅 local git，禁止 remote closure/merge；D=remote 不可靠，仅 plan/prompt pack。
-- queue_gate 必须包含 remote_refresh：origin/main 当前 SHA、lane base SHA、是否 stale_base、处理策略。
+- queue_gate 必须包含 remote_refresh：origin/main 当前 SHA、lane base SHA、是否 stale_base、处理策略、`owner_lane=coordinator|verification_owner`。
+- `git fetch --prune origin` 默认由 root orchestrator / verification_owner 串行执行，并把 remote snapshot 传给只读 lanes；只读 lane 只有在隔离 worktree 且 lane_map 明确允许时才自己 fetch。
 - 输出 queue_ledger，并在每个 queue item 上记录 owner_lane、head_sha、ci_status、review_thread_state、acceptance_evidence、remote_checked_at。
 - lane_map 每个 spawned lane 必须记录 `native_thread_id`；coordinator-only lane 必须写 `native_thread_id: none` 和需要时的 `no_spawn_reason`。
 - issue_to_pr_map 必须先判断 open issue 是否已有覆盖 PR；优先收敛已有 PR，不要开竞争 PR。
@@ -62,7 +63,7 @@ Target queue: {{queue_scope}}
 请读取 repo 指令，并用当前 session 的 live remote state 完成队列门。
 
 必须检查：
-1. git fetch --prune 后的当前 branch、dirty files、unpushed commits、worktrees。
+1. 使用 coordinator 提供的 fresh remote snapshot；如果被明确授权在隔离 worktree 内 fetch，再记录 git fetch --prune 后的当前 branch、dirty files、unpushed commits、worktrees。
 2. 可用 remote truth level：A/B/C/D，并说明缺失的工具或权限。
 3. origin/main 当前 SHA、每个候选 lane 的 base_ref 是否 stale、是否需要 rebase/recreate/stop。
 4. open PRs 和 open issues。
@@ -90,7 +91,7 @@ Target queue: {{queue_scope}}
 规则：
 - MERGEABLE/CLEAN 不足以判定 merge_ready；必须同时有当前 head SHA、check rollup、merge state、GraphQL review-thread state。
 - review-gated queue 默认一次收敛一个 blocker，除非 writable_files 明确不重叠且 PR 不 stacked。
-- remote_refresh 只能 fetch 和比较；不要在 queue gate 自动 rebase/merge。
+- remote_refresh 默认由 coordinator 串行执行；queue gate thread 不要在共享 worktree 内 fetch、rebase 或 merge。
 - GraphQL 不可用时最多 truth_level=B，允许 review/实现，不允许 merge。
 - contributor PR 可维护修改时，不要默认开替代 PR。
 ```
@@ -331,7 +332,7 @@ No findings; safe to merge.
 - gh issue list
 - GraphQL reviewThreads.isResolved for touched PRs
 - PR conversation comments, review comments, and whether fixed feedback has replies/resolution
-- git fetch --prune
+- coordinator-provided git fetch --prune snapshot；只有隔离 worktree 才由本 lane 自行 fetch
 - git status --short --branch
 - git log origin/main..HEAD
 - git diff --stat origin/main...HEAD

--- a/skills/threads/references/run-log.md
+++ b/skills/threads/references/run-log.md
@@ -41,10 +41,14 @@ Do not use a global log file by default; different repositories should not
 share durable threads telemetry unless the user explicitly sets
 `CODEX_THREADS_RUN_LOG`.
 
-Append one JSON object per run:
+Append one JSON object per run. In the Spellbook source checkout the script is
+available at `skills/threads/scripts/append_run_log.py`. In an installed skill,
+resolve the script relative to the loaded `threads` skill directory; do not
+assume the target repository contains a `skills/threads` path.
 
 ```bash
-python3 skills/threads/scripts/append_run_log.py <<'JSON'
+THREADS_SKILL_DIR=${THREADS_SKILL_DIR:-skills/threads}
+python3 "$THREADS_SKILL_DIR/scripts/append_run_log.py" <<'JSON'
 {
   "skill": "threads",
   "mode": "execute_direct",
@@ -155,6 +159,7 @@ Recommended fields:
     "queue_tranche": "first blocker"
   },
   "remote_refresh": {
+    "owner_lane": "coordinator",
     "cadence": "queue_start|before_lane|before_push|before_merge|after_ci_wait",
     "origin_main_sha": "abc123",
     "local_base_sha": "def456",
@@ -167,6 +172,13 @@ Recommended fields:
     "items_closed": 0,
     "items_deferred": 0,
     "superseded_items": []
+  },
+  "queue_gate": {
+    "fetched_remote": true,
+    "truth_level": "A",
+    "pr_classification": [],
+    "open_prs": [],
+    "open_issues": []
   },
   "lanes_total": 0,
   "lanes": [
@@ -254,7 +266,13 @@ Safety limits:
 - maximum nesting depth: 8
 - maximum array items retained: 100
 - new log files are created with `0600` permissions
+- existing log files are tightened to `0600` before append
 - append uses a POSIX file lock when available
+
+When `queue_gate` is present, include a `remote_refresh` contract with
+`owner_lane`, `origin_main_sha`, `local_base_sha`, `stale_base`, and `policy`.
+Allowed owners are `coordinator` and `verification_owner`; read-only lanes should
+consume this snapshot unless they are explicitly isolated.
 
 ## Failure Codes
 
@@ -290,9 +308,10 @@ Use stable codes so later analysis can aggregate them:
 Common local checks:
 
 ```bash
-jq -r '.failure_codes[]?' "$(git rev-parse --git-dir)/codex/threads/run-log.jsonl" | sort | uniq -c | sort -nr
-jq -r 'select(.outcome!="success") | [.recorded_at_utc,.repo,.mode,.failure_codes|join(",")] | @tsv' "$(git rev-parse --git-dir)/codex/threads/run-log.jsonl"
-jq -r 'select(.verification.fresh==false) | [.recorded_at_utc,.repo,.goal] | @tsv' "$(git rev-parse --git-dir)/codex/threads/run-log.jsonl"
+LOG="$(git rev-parse --git-dir)/codex/threads/run-log.jsonl"
+test -f "$LOG" && jq -r '.failure_codes[]?' "$LOG" | sort | uniq -c | sort -nr
+test -f "$LOG" && jq -r 'select(.outcome!="success") | [.recorded_at_utc,.repo,.mode,((.failure_codes // [])|join(","))] | @tsv' "$LOG"
+test -f "$LOG" && jq -r 'select(.verification.fresh==false) | [.recorded_at_utc,.repo,.goal] | @tsv' "$LOG"
 ```
 
 ## Privacy

--- a/skills/threads/scripts/append_run_log.py
+++ b/skills/threads/scripts/append_run_log.py
@@ -41,6 +41,30 @@ ALLOWED_MODES = {
 }
 ALLOWED_TRUTH_LEVELS = {"A", "B", "C", "D"}
 ALLOWED_FALLBACK_MODES = {"none", "single_agent", "prompt_pack_only"}
+ALLOWED_NATIVE_SUBAGENTS = {"available", "unavailable"}
+ALLOWED_SPAWN_REQUIREMENTS = {"required", "optional", "unavailable"}
+ALLOWED_DATA_COLLECTION = {"final_report", "local_jsonl", "none"}
+ALLOWED_OUTCOMES = {"success", "partial", "blocked", "failed"}
+ALLOWED_REMOTE_REFRESH_OWNERS = {"coordinator", "verification_owner"}
+ALLOWED_REMOTE_REFRESH_POLICIES = {"continue", "rebase", "required_stop"}
+ALLOWED_PR_CLASSIFICATIONS = {
+    "merge_ready",
+    "review_thread_blocked",
+    "ci_failed",
+    "conflict_blocked",
+    "stale_or_superseded",
+    "needs_human_decision",
+}
+ALLOWED_LANE_ROLES = {
+    "planner",
+    "worker",
+    "reviewer",
+    "merge_reviewer",
+    "researcher",
+    "fix_worker",
+    "closure_auditor",
+}
+ALLOWED_VERIFICATION_SCOPES = {"inspection_only", "targeted", "full_local", "ci_only"}
 ALLOWED_NATIVE_SPAWN_TOOLS = {"multi_agent_v1.spawn_agent"}
 INVALID_AGENT_IDS = {"", "none", "n/a", "na", "null", "main", "main_thread", "coordinator"}
 ALLOWED_SINGLE_AGENT_REASONS = {
@@ -75,6 +99,7 @@ ALLOWED_TOP_LEVEL_FIELDS = {
     "single_agent_justification",
     "capability_gate",
     "thread_dispatch_gate",
+    "queue_gate",
     "queue_bounds",
     "remote_refresh",
     "queue_ledger",
@@ -95,6 +120,36 @@ ALLOWED_TOP_LEVEL_FIELDS = {
     "outcome",
     "notes",
 }
+ALLOWED_FAILURE_CODES = {
+    "trigger_too_broad",
+    "missing_intent_contract",
+    "durable_log_skipped",
+    "truth_level_too_low",
+    "source_drift",
+    "active_skill_source_unknown",
+    "stale_remote_state",
+    "stale_base",
+    "duplicate_work_missed",
+    "contributor_pr_replaced_unnecessarily",
+    "role_drift",
+    "write_scope_violation",
+    "vague_lane_output",
+    "verification_gap",
+    "review_thread_missed",
+    "connector_review_incomplete",
+    "review_loop",
+    "native_thread_not_spawned",
+    "waiting_ci",
+    "merge_gate_bypass",
+    "tool_unavailable",
+    "environment_mismatch",
+    "context_loss",
+    "user_interrupt",
+}
+SENSITIVE_ENV_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*)"
+    r"\s*=\s*([^\s,;]+)"
+)
 
 SENSITIVE_PATTERNS = (
     re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.DOTALL),
@@ -148,7 +203,7 @@ def default_log_path() -> Path:
 
 
 def redact_string(value: str) -> str:
-    redacted = value
+    redacted = SENSITIVE_ENV_ASSIGNMENT_PATTERN.sub(r"\1=[REDACTED]", value)
     for pattern in SENSITIVE_PATTERNS:
         redacted = pattern.sub("[REDACTED]", redacted)
     if len(redacted) > MAX_STRING_LENGTH:
@@ -185,11 +240,131 @@ def normalize_record(raw: Any, allow_extra: bool = False) -> dict[str, Any]:
     truth_level = record.get("truth_level")
     if truth_level is not None and truth_level not in ALLOWED_TRUTH_LEVELS:
         raise ValueError(f"unknown truth_level: {truth_level}")
+    validate_enum_fields(record)
     validate_native_thread_evidence(record)
 
     record.setdefault("schema_version", 1)
     record["recorded_at_utc"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
     return record
+
+
+def validate_enum(value: Any, allowed: set[str], field: str) -> None:
+    if value is not None and value not in allowed:
+        raise ValueError(f"unknown {field}: {value}")
+
+
+def validate_failure_codes(record: dict[str, Any]) -> None:
+    failure_codes = record.get("failure_codes")
+    if failure_codes is None:
+        return
+    if not isinstance(failure_codes, list):
+        raise ValueError("failure_codes must be a list")
+    unknown = sorted(
+        code
+        for code in failure_codes
+        if not isinstance(code, str) or code not in ALLOWED_FAILURE_CODES
+    )
+    if unknown:
+        raise ValueError("unknown failure_codes: " + ", ".join(map(str, unknown)))
+
+
+def validate_lanes(record: dict[str, Any]) -> None:
+    lanes = record.get("lanes")
+    if lanes is None:
+        return
+    if not isinstance(lanes, list):
+        raise ValueError("lanes must be a list")
+    for lane in lanes:
+        if not isinstance(lane, dict):
+            raise ValueError("lanes entries must be objects")
+        validate_enum(lane.get("role"), ALLOWED_LANE_ROLES, "lanes.role")
+        validate_enum(
+            lane.get("verification_scope"),
+            ALLOWED_VERIFICATION_SCOPES,
+            "lanes.verification_scope",
+        )
+
+
+def validate_enum_fields(record: dict[str, Any]) -> None:
+    validate_enum(nested_get(record, "native_subagents"), ALLOWED_NATIVE_SUBAGENTS, "native_subagents")
+    validate_enum(
+        nested_get(record, "spawn_requirement"),
+        ALLOWED_SPAWN_REQUIREMENTS,
+        "spawn_requirement",
+    )
+    validate_enum(record.get("data_collection"), ALLOWED_DATA_COLLECTION, "data_collection")
+    intent_contract = record.get("intent_contract")
+    if isinstance(intent_contract, dict):
+        validate_enum(
+            intent_contract.get("data_collection"),
+            ALLOWED_DATA_COLLECTION,
+            "intent_contract.data_collection",
+        )
+    validate_enum(record.get("outcome"), ALLOWED_OUTCOMES, "outcome")
+    validate_queue_gate(record)
+    validate_failure_codes(record)
+    validate_lanes(record)
+
+
+def remote_refresh_contract(record: dict[str, Any]) -> dict[str, Any] | None:
+    remote_refresh = record.get("remote_refresh")
+    if isinstance(remote_refresh, dict):
+        return remote_refresh
+    queue_gate = record.get("queue_gate")
+    if isinstance(queue_gate, dict):
+        nested = queue_gate.get("remote_refresh")
+        if isinstance(nested, dict):
+            return nested
+    return None
+
+
+def validate_queue_gate(record: dict[str, Any]) -> None:
+    queue_gate = record.get("queue_gate")
+    if queue_gate is None:
+        return
+    if not isinstance(queue_gate, dict):
+        raise ValueError("queue_gate must be an object")
+
+    queue_truth_level = queue_gate.get("truth_level")
+    validate_enum(queue_truth_level, ALLOWED_TRUTH_LEVELS, "queue_gate.truth_level")
+    top_truth_level = record.get("truth_level")
+    if (
+        top_truth_level is not None
+        and queue_truth_level is not None
+        and top_truth_level != queue_truth_level
+    ):
+        raise ValueError("conflicting truth_level values across top-level and queue_gate")
+
+    remote_refresh = remote_refresh_contract(record)
+    if remote_refresh is None:
+        raise ValueError("remote_refresh is required when queue_gate is present")
+    for field in ("owner_lane", "policy", "origin_main_sha", "local_base_sha", "stale_base"):
+        if field not in remote_refresh:
+            raise ValueError(f"remote_refresh.{field} is required when queue_gate is present")
+    validate_enum(
+        remote_refresh.get("owner_lane"),
+        ALLOWED_REMOTE_REFRESH_OWNERS,
+        "remote_refresh.owner_lane",
+    )
+    validate_enum(
+        remote_refresh.get("policy"),
+        ALLOWED_REMOTE_REFRESH_POLICIES,
+        "remote_refresh.policy",
+    )
+
+    pr_classification = queue_gate.get("pr_classification", [])
+    if pr_classification is None:
+        return
+    if not isinstance(pr_classification, list):
+        raise ValueError("queue_gate.pr_classification must be a list")
+    for item in pr_classification:
+        if not isinstance(item, dict):
+            raise ValueError("queue_gate.pr_classification entries must be objects")
+        validate_enum(
+            item.get("classification"),
+            ALLOWED_PR_CLASSIFICATIONS,
+            "queue_gate.pr_classification.classification",
+        )
 
 
 def truthy(value: Any) -> bool:
@@ -423,6 +598,7 @@ def validate_native_thread_evidence(record: dict[str, Any]) -> None:
 def append_record(record: dict[str, Any], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    os.chmod(path, 0o600)
     with os.fdopen(fd, "a", encoding="utf-8") as handle:
         if fcntl is not None:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
@@ -456,18 +632,34 @@ def main() -> int:
         action="store_true",
         help="Allow unknown top-level fields after redaction. Defaults to rejecting them.",
     )
+    parser.add_argument(
+        "--print-path",
+        action="store_true",
+        help="Print the resolved JSONL path and exit without reading stdin.",
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Validate and redact stdin JSON without appending a log record.",
+    )
     args = parser.parse_args()
 
     try:
-        raw = load_input()
-        record = normalize_record(raw, allow_extra=args.allow_extra)
         path = args.path.expanduser() if args.path is not None else default_log_path()
-        append_record(record, path)
+        if args.print_path:
+            output_path = path
+        else:
+            raw = load_input()
+            record = normalize_record(raw, allow_extra=args.allow_extra)
+            if args.validate_only:
+                return 0
+            append_record(record, path)
+            output_path = path
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         print(f"append_run_log.py: {exc}", file=sys.stderr)
         return 1
 
-    print(str(path))
+    sys.stdout.write(str(output_path) + "\n")
     return 0
 
 

--- a/tests/test_threads_run_log.py
+++ b/tests/test_threads_run_log.py
@@ -152,6 +152,112 @@ class ThreadsRunLogTests(unittest.TestCase):
             self.assertEqual(record["remote_truth"]["origin_main_sha"], "abc123")
             self.assertFalse(record["local_state"]["dirty_worktree"])
 
+    def test_allows_queue_gate_from_skill_contract(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "queue-gate.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "plan_only",
+                    "queue_gate": {
+                        "fetched_remote": True,
+                        "truth_level": "A",
+                        "open_prs": [],
+                        "open_issues": [],
+                    },
+                    "remote_refresh": {
+                        "owner_lane": "coordinator",
+                        "origin_main_sha": "abc123",
+                        "local_base_sha": "abc123",
+                        "stale_base": False,
+                        "policy": "continue",
+                    },
+                },
+                log_path,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertTrue(record["queue_gate"]["fetched_remote"])
+
+    def test_rejects_queue_gate_without_remote_refresh_owner(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "queue-missing-owner.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "plan_only",
+                    "queue_gate": {"truth_level": "A"},
+                    "remote_refresh": {
+                        "origin_main_sha": "abc123",
+                        "local_base_sha": "abc123",
+                        "stale_base": False,
+                        "policy": "continue",
+                    },
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("remote_refresh.owner_lane", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_rejects_queue_gate_unknown_pr_classification(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "queue-pr-classification.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "plan_only",
+                    "queue_gate": {
+                        "truth_level": "A",
+                        "pr_classification": [
+                            {"PR": 1, "classification": "looks_good"},
+                        ],
+                    },
+                    "remote_refresh": {
+                        "owner_lane": "coordinator",
+                        "origin_main_sha": "abc123",
+                        "local_base_sha": "abc123",
+                        "stale_base": False,
+                        "policy": "continue",
+                    },
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("queue_gate.pr_classification.classification", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_rejects_conflicting_top_level_and_queue_gate_truth_level(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "queue-truth-conflict.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "plan_only",
+                    "truth_level": "A",
+                    "queue_gate": {"truth_level": "B"},
+                    "remote_refresh": {
+                        "owner_lane": "coordinator",
+                        "origin_main_sha": "abc123",
+                        "local_base_sha": "abc123",
+                        "stale_base": False,
+                        "policy": "continue",
+                    },
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("conflicting truth_level", result.stderr)
+            self.assertFalse(log_path.exists())
+
     def test_accepts_clarify_first_mode(self):
         with TemporaryDirectory() as temp_dir:
             log_path = Path(temp_dir) / "clarify.jsonl"
@@ -655,6 +761,74 @@ class ThreadsRunLogTests(unittest.TestCase):
             self.assertIn("unknown truth_level", result.stderr)
             self.assertFalse(log_path.exists())
 
+    def test_rejects_unknown_native_subagents_value(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "native-enum.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "plan_only",
+                    "native_subagents": "maybe",
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unknown native_subagents", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_rejects_unknown_spawn_requirement_value(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "spawn-enum.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "plan_only",
+                    "spawn_requirement": "mandatory",
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unknown spawn_requirement", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_rejects_unknown_failure_code(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "failure-code.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "plan_only",
+                    "failure_codes": ["made_up_failure"],
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unknown failure_codes", result.stderr)
+            self.assertFalse(log_path.exists())
+
+    def test_rejects_unknown_lane_role(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "lane-role.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "plan_only",
+                    "lanes": [{"id": "x", "role": "boss"}],
+                },
+                log_path,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unknown lanes.role", result.stderr)
+            self.assertFalse(log_path.exists())
+
     def test_allow_extra_preserves_redacted_unknown_top_level_fields(self):
         with TemporaryDirectory() as temp_dir:
             log_path = Path(temp_dir) / "extra.jsonl"
@@ -677,6 +851,24 @@ class ThreadsRunLogTests(unittest.TestCase):
             record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
             self.assertEqual(record["extra"]["token"], "[REDACTED]")
 
+    def test_redacts_env_assignment_tokens_in_strings(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "env-token.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "plan_only",
+                    "notes": "ran API_TOKEN=super-secret-token command",
+                },
+                log_path,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertNotIn("super-secret-token", record["notes"])
+            self.assertIn("API_TOKEN=[REDACTED]", record["notes"])
+
     def test_new_log_file_is_private(self):
         with TemporaryDirectory() as temp_dir:
             log_path = Path(temp_dir) / "private.jsonl"
@@ -692,6 +884,55 @@ class ThreadsRunLogTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             mode = stat.S_IMODE(log_path.stat().st_mode)
             self.assertEqual(mode, 0o600)
+
+    def test_existing_log_file_permissions_are_tightened(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "existing.jsonl"
+            log_path.write_text("", encoding="utf-8")
+            log_path.chmod(0o644)
+
+            result = self.run_script({"skill": "threads", "mode": "plan_only"}, log_path)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            mode = stat.S_IMODE(log_path.stat().st_mode)
+            self.assertEqual(mode, 0o600)
+
+    def test_print_path_does_not_require_stdin(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "print-path.jsonl"
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--path", str(log_path), "--print-path"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), str(log_path))
+            self.assertFalse(log_path.exists())
+
+    def test_validate_only_does_not_append(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "validate-only.jsonl"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--path",
+                    str(log_path),
+                    "--validate-only",
+                ],
+                input=json.dumps({"skill": "threads", "mode": "plan_only"}),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse(log_path.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `docs/threads-run-governance-spec.md` for the threads run evidence contract, queue ownership, durable logging defaults, and follow-up tranche map.
- Makes `queue_gate` a first-class run-log field and requires `remote_refresh.owner_lane`, `origin_main_sha`, `local_base_sha`, `stale_base`, and `policy` when queue evidence is logged.
- Adds lightweight enum validation for dispatch, lanes, remote refresh, queue PR classification, failure codes, and outcomes.
- Adds `--print-path`, `--validate-only`, existing-log `0600` tightening, and `KEY=value` secret assignment redaction.
- Updates `threads` quick path, prompt patterns, and run-log docs to align with coordinator-owned remote refresh.

Closes #113.
Follow-ups: #114, #115, #116, #117, #118.

## Base

- Fresh `origin/main`: `5ba135ecee94732e9f078858b0bdad47f64d09f9`
- Branch merge-base with `origin/main`: `5ba135ecee94732e9f078858b0bdad47f64d09f9`
- Isolated worktree: `/Users/lifcc/Desktop/code/AI/tools/spellbook-threads-originmain`

## Threads Evidence

- Planner lane: `019efabf-aebd-7e41-9d4b-4d8c48a68520`
- Risk/reviewer lane: `019efabf-c33a-7831-bff6-be461f26bd90`
- Coordinator owned remote refresh; read-only lanes consumed the fresh snapshot.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_threads_run_log -q` passed: 39 tests.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -q` passed: 106 tests.
- `python3 -m py_compile skills/threads/scripts/append_run_log.py` passed.
- `python3 scripts/validate_skills.py --check` passed with 0 errors and 1 existing length warning for `skills/threads/SKILL.md`.
- `python3 scripts/audit_skill_quality.py threads` passed with 0 warnings and 0 info.
- `git diff --cached --check` passed before commit.
