### PR TITLE
test(threads): add trigger boundary eval fixtures

### DIFF
--- a/skills/threads/SKILL.md
+++ b/skills/threads/SKILL.md
@@ -495,3 +495,4 @@ remote_closure:
 - Classify failures as specification/system design, inter-agent misalignment, or verification/termination before retrying.
 - If long-running remote state changes underneath a lane, record `stale_remote_state` and refresh/rebase only through an explicit gate; do not silently continue on a stale base.
 - If no native subagent capability is available, return the lane map and exact prompts so the user can launch them manually.
+- Trigger boundary fixtures live in `evals/evals.json`; use them when changing the skill description, dispatch modes, or near-boundary "thread" wording.

--- a/skills/threads/evals/evals.json
+++ b/skills/threads/evals/evals.json
@@ -1,126 +1,122 @@
-{
-  "skill_name": "threads",
-  "description": "Trigger-boundary fixtures for Codex-native subagent orchestration and GitHub issue/PR queue handling. These prompts are local-only and do not require live GitHub or network state.",
-  "evals": [
-    {
-      "id": 1,
-      "name": "explicit-codex-native-subagents",
-      "prompt": "Use threads to split this repository cleanup into independent Codex subagents with separate file ownership and review gates.",
-      "should_trigger": true,
-      "expected_mode": "execute_direct",
-      "expected_output": "Uses the threads skill, records capability and dispatch gates, creates a lane map with disjoint writable files, and does not route to tmux or OS-level threads.",
-      "category": "positive-native-dispatch",
-      "files": []
-    },
-    {
-      "id": 2,
-      "name": "github-queue-sweep",
-      "prompt": "Use threads to process this repo's open GitHub issues and PRs, including review-thread blockers and merge readiness.",
-      "should_trigger": true,
-      "expected_mode": "execute_direct",
-      "expected_output": "Starts with live queue gate requirements, maps issues to PRs, requires GraphQL reviewThreads, and bounds the queue tranche before implementation.",
-      "category": "positive-github-queue",
-      "files": []
-    },
-    {
-      "id": 3,
-      "name": "review-only-pr",
-      "prompt": "Open a read-only threads review for PR #42 and tell me whether it is safe to merge.",
-      "should_trigger": true,
-      "expected_mode": "review_only",
-      "expected_output": "Plans a read-only reviewer or merge-reviewer lane, checks current head, CI, merge state, and thread-aware review-thread state, and does not edit files.",
-      "category": "positive-review-only",
-      "files": []
-    },
-    {
-      "id": 4,
-      "name": "research-spec-lanes",
-      "prompt": "Use threads to research this agent workflow from product, engineering, and security angles, then synthesize a spec.",
-      "should_trigger": true,
-      "expected_mode": "research_spec",
-      "expected_output": "Splits read-only research lanes by angle, records evidence expectations, and synthesizes without assigning overlapping writable workers.",
-      "category": "positive-research-spec",
-      "files": []
-    },
-    {
-      "id": 5,
-      "name": "chinese-subagent-request",
-      "prompt": "开几个子 agent 分别看这个 PR 的测试、架构和安全问题，最后汇总能不能合并。",
-      "should_trigger": true,
-      "expected_mode": "review_only",
-      "expected_output": "Recognizes the explicit subagent request, uses native Codex threads when available, and assigns read-only reviewer lanes with merge-gate evidence.",
-      "category": "positive-native-dispatch",
-      "files": []
-    },
-    {
-      "id": 6,
-      "name": "os-threading-question",
-      "prompt": "Explain how Python threads differ from multiprocessing for CPU-bound code.",
-      "should_trigger": false,
-      "expected_mode": "single_agent",
-      "expected_output": "Answers as an ordinary programming/concurrency question without loading the threads workflow orchestration skill.",
-      "category": "negative-language-concurrency",
-      "files": []
-    },
-    {
-      "id": 7,
-      "name": "rust-thread-bug",
-      "prompt": "My Rust worker threads deadlock when two mutexes are acquired in opposite order. Help me debug the code.",
-      "should_trigger": false,
-      "expected_mode": "single_agent",
-      "expected_output": "Treats this as a Rust concurrency debugging task and does not create Codex lane maps or GitHub queue gates unless separately requested.",
-      "category": "negative-language-concurrency",
-      "files": []
-    },
-    {
-      "id": 8,
-      "name": "forum-thread-summary",
-      "prompt": "Summarize this long forum thread and extract the main arguments.",
-      "should_trigger": false,
-      "expected_mode": "single_agent",
-      "expected_output": "Treats thread as a discussion artifact, not Codex subagent orchestration.",
-      "category": "negative-discussion-thread",
-      "files": []
-    },
-    {
-      "id": 9,
-      "name": "email-thread-reply",
-      "prompt": "Draft a concise reply to this email thread and keep the tone professional.",
-      "should_trigger": false,
-      "expected_mode": "single_agent",
-      "expected_output": "Handles email writing directly without capability gates, queue gates, or native subagent dispatch.",
-      "category": "negative-discussion-thread",
-      "files": []
-    },
-    {
-      "id": 10,
-      "name": "assistants-api-thread",
-      "prompt": "How do I create and retrieve threads in the OpenAI Assistants API?",
-      "should_trigger": false,
-      "expected_mode": "single_agent",
-      "expected_output": "Routes to OpenAI API documentation/help rather than Codex workflow orchestration.",
-      "category": "negative-product-api-thread",
-      "files": []
-    },
-    {
-      "id": 11,
-      "name": "ambiguous-one-file-task",
-      "prompt": "Fix this one typo in README.md; no agents needed.",
-      "should_trigger": false,
-      "expected_mode": "single_agent",
-      "expected_output": "Uses a simple single-agent edit path because the user explicitly rejects agent dispatch and the task is tiny.",
-      "category": "negative-simple-task",
-      "files": []
-    },
-    {
-      "id": 12,
-      "name": "github-queue-plan-only",
-      "prompt": "Use threads to map all open PRs and issues, but do not edit or merge anything yet.",
-      "should_trigger": true,
-      "expected_mode": "plan_only",
-      "expected_output": "Runs queue gate and lane planning only, classifies PRs and issues, and stops before edits, comments, pushes, or merges.",
-      "category": "positive-plan-only",
-      "files": []
-    }
-  ]
-}
+[
+  {
+    "id": 1,
+    "name": "explicit-codex-native-subagents",
+    "should_trigger": true,
+    "expected_mode": "execute_direct",
+    "expected_output": "Uses the threads skill, records capability and dispatch gates, creates a lane map with disjoint writable files, and does not route to tmux or OS-level threads.",
+    "category": "positive-native-dispatch",
+    "files": [],
+    "query": "Use threads to split this repository cleanup into independent Codex subagents with separate file ownership and review gates."
+  },
+  {
+    "id": 2,
+    "name": "github-queue-sweep",
+    "should_trigger": true,
+    "expected_mode": "execute_direct",
+    "expected_output": "Starts with live queue gate requirements, maps issues to PRs, requires GraphQL reviewThreads, and bounds the queue tranche before implementation.",
+    "category": "positive-github-queue",
+    "files": [],
+    "query": "Use threads to process this repo's open GitHub issues and PRs, including review-thread blockers and merge readiness."
+  },
+  {
+    "id": 3,
+    "name": "review-only-pr",
+    "should_trigger": true,
+    "expected_mode": "review_only",
+    "expected_output": "Plans a read-only reviewer or merge-reviewer lane, checks current head, CI, merge state, and thread-aware review-thread state, and does not edit files.",
+    "category": "positive-review-only",
+    "files": [],
+    "query": "Open a read-only threads review for PR #42 and tell me whether it is safe to merge."
+  },
+  {
+    "id": 4,
+    "name": "research-spec-lanes",
+    "should_trigger": true,
+    "expected_mode": "research_spec",
+    "expected_output": "Splits read-only research lanes by angle, records evidence expectations, and synthesizes without assigning overlapping writable workers.",
+    "category": "positive-research-spec",
+    "files": [],
+    "query": "Use threads to research this agent workflow from product, engineering, and security angles, then synthesize a spec."
+  },
+  {
+    "id": 5,
+    "name": "chinese-subagent-request",
+    "should_trigger": true,
+    "expected_mode": "review_only",
+    "expected_output": "Recognizes the explicit subagent request, uses native Codex threads when available, and assigns read-only reviewer lanes with merge-gate evidence.",
+    "category": "positive-native-dispatch",
+    "files": [],
+    "query": "开几个子 agent 分别看这个 PR 的测试、架构和安全问题，最后汇总能不能合并。"
+  },
+  {
+    "id": 6,
+    "name": "os-threading-question",
+    "should_trigger": false,
+    "expected_mode": "single_agent",
+    "expected_output": "Answers as an ordinary programming/concurrency question without loading the threads workflow orchestration skill.",
+    "category": "negative-language-concurrency",
+    "files": [],
+    "query": "Explain how Python threads differ from multiprocessing for CPU-bound code."
+  },
+  {
+    "id": 7,
+    "name": "rust-thread-bug",
+    "should_trigger": false,
+    "expected_mode": "single_agent",
+    "expected_output": "Treats this as a Rust concurrency debugging task and does not create Codex lane maps or GitHub queue gates unless separately requested.",
+    "category": "negative-language-concurrency",
+    "files": [],
+    "query": "My Rust worker threads deadlock when two mutexes are acquired in opposite order. Help me debug the code."
+  },
+  {
+    "id": 8,
+    "name": "forum-thread-summary",
+    "should_trigger": false,
+    "expected_mode": "single_agent",
+    "expected_output": "Treats thread as a discussion artifact, not Codex subagent orchestration.",
+    "category": "negative-discussion-thread",
+    "files": [],
+    "query": "Summarize this long forum thread and extract the main arguments."
+  },
+  {
+    "id": 9,
+    "name": "email-thread-reply",
+    "should_trigger": false,
+    "expected_mode": "single_agent",
+    "expected_output": "Handles email writing directly without capability gates, queue gates, or native subagent dispatch.",
+    "category": "negative-discussion-thread",
+    "files": [],
+    "query": "Draft a concise reply to this email thread and keep the tone professional."
+  },
+  {
+    "id": 10,
+    "name": "assistants-api-thread",
+    "should_trigger": false,
+    "expected_mode": "single_agent",
+    "expected_output": "Routes to OpenAI API documentation/help rather than Codex workflow orchestration.",
+    "category": "negative-product-api-thread",
+    "files": [],
+    "query": "How do I create and retrieve threads in the OpenAI Assistants API?"
+  },
+  {
+    "id": 11,
+    "name": "ambiguous-one-file-task",
+    "should_trigger": false,
+    "expected_mode": "single_agent",
+    "expected_output": "Uses a simple single-agent edit path because the user explicitly rejects agent dispatch and the task is tiny.",
+    "category": "negative-simple-task",
+    "files": [],
+    "query": "Fix this one typo in README.md; no agents needed."
+  },
+  {
+    "id": 12,
+    "name": "github-queue-plan-only",
+    "should_trigger": true,
+    "expected_mode": "plan_only",
+    "expected_output": "Runs queue gate and lane planning only, classifies PRs and issues, and stops before edits, comments, pushes, or merges.",
+    "category": "positive-plan-only",
+    "files": [],
+    "query": "Use threads to map all open PRs and issues, but do not edit or merge anything yet."
+  }
+]

--- a/skills/threads/evals/evals.json
+++ b/skills/threads/evals/evals.json
@@ -1,0 +1,126 @@
+{
+  "skill_name": "threads",
+  "description": "Trigger-boundary fixtures for Codex-native subagent orchestration and GitHub issue/PR queue handling. These prompts are local-only and do not require live GitHub or network state.",
+  "evals": [
+    {
+      "id": 1,
+      "name": "explicit-codex-native-subagents",
+      "prompt": "Use threads to split this repository cleanup into independent Codex subagents with separate file ownership and review gates.",
+      "should_trigger": true,
+      "expected_mode": "execute_direct",
+      "expected_output": "Uses the threads skill, records capability and dispatch gates, creates a lane map with disjoint writable files, and does not route to tmux or OS-level threads.",
+      "category": "positive-native-dispatch",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "github-queue-sweep",
+      "prompt": "Use threads to process this repo's open GitHub issues and PRs, including review-thread blockers and merge readiness.",
+      "should_trigger": true,
+      "expected_mode": "execute_direct",
+      "expected_output": "Starts with live queue gate requirements, maps issues to PRs, requires GraphQL reviewThreads, and bounds the queue tranche before implementation.",
+      "category": "positive-github-queue",
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "review-only-pr",
+      "prompt": "Open a read-only threads review for PR #42 and tell me whether it is safe to merge.",
+      "should_trigger": true,
+      "expected_mode": "review_only",
+      "expected_output": "Plans a read-only reviewer or merge-reviewer lane, checks current head, CI, merge state, and thread-aware review-thread state, and does not edit files.",
+      "category": "positive-review-only",
+      "files": []
+    },
+    {
+      "id": 4,
+      "name": "research-spec-lanes",
+      "prompt": "Use threads to research this agent workflow from product, engineering, and security angles, then synthesize a spec.",
+      "should_trigger": true,
+      "expected_mode": "research_spec",
+      "expected_output": "Splits read-only research lanes by angle, records evidence expectations, and synthesizes without assigning overlapping writable workers.",
+      "category": "positive-research-spec",
+      "files": []
+    },
+    {
+      "id": 5,
+      "name": "chinese-subagent-request",
+      "prompt": "开几个子 agent 分别看这个 PR 的测试、架构和安全问题，最后汇总能不能合并。",
+      "should_trigger": true,
+      "expected_mode": "review_only",
+      "expected_output": "Recognizes the explicit subagent request, uses native Codex threads when available, and assigns read-only reviewer lanes with merge-gate evidence.",
+      "category": "positive-native-dispatch",
+      "files": []
+    },
+    {
+      "id": 6,
+      "name": "os-threading-question",
+      "prompt": "Explain how Python threads differ from multiprocessing for CPU-bound code.",
+      "should_trigger": false,
+      "expected_mode": "single_agent",
+      "expected_output": "Answers as an ordinary programming/concurrency question without loading the threads workflow orchestration skill.",
+      "category": "negative-language-concurrency",
+      "files": []
+    },
+    {
+      "id": 7,
+      "name": "rust-thread-bug",
+      "prompt": "My Rust worker threads deadlock when two mutexes are acquired in opposite order. Help me debug the code.",
+      "should_trigger": false,
+      "expected_mode": "single_agent",
+      "expected_output": "Treats this as a Rust concurrency debugging task and does not create Codex lane maps or GitHub queue gates unless separately requested.",
+      "category": "negative-language-concurrency",
+      "files": []
+    },
+    {
+      "id": 8,
+      "name": "forum-thread-summary",
+      "prompt": "Summarize this long forum thread and extract the main arguments.",
+      "should_trigger": false,
+      "expected_mode": "single_agent",
+      "expected_output": "Treats thread as a discussion artifact, not Codex subagent orchestration.",
+      "category": "negative-discussion-thread",
+      "files": []
+    },
+    {
+      "id": 9,
+      "name": "email-thread-reply",
+      "prompt": "Draft a concise reply to this email thread and keep the tone professional.",
+      "should_trigger": false,
+      "expected_mode": "single_agent",
+      "expected_output": "Handles email writing directly without capability gates, queue gates, or native subagent dispatch.",
+      "category": "negative-discussion-thread",
+      "files": []
+    },
+    {
+      "id": 10,
+      "name": "assistants-api-thread",
+      "prompt": "How do I create and retrieve threads in the OpenAI Assistants API?",
+      "should_trigger": false,
+      "expected_mode": "single_agent",
+      "expected_output": "Routes to OpenAI API documentation/help rather than Codex workflow orchestration.",
+      "category": "negative-product-api-thread",
+      "files": []
+    },
+    {
+      "id": 11,
+      "name": "ambiguous-one-file-task",
+      "prompt": "Fix this one typo in README.md; no agents needed.",
+      "should_trigger": false,
+      "expected_mode": "single_agent",
+      "expected_output": "Uses a simple single-agent edit path because the user explicitly rejects agent dispatch and the task is tiny.",
+      "category": "negative-simple-task",
+      "files": []
+    },
+    {
+      "id": 12,
+      "name": "github-queue-plan-only",
+      "prompt": "Use threads to map all open PRs and issues, but do not edit or merge anything yet.",
+      "should_trigger": true,
+      "expected_mode": "plan_only",
+      "expected_output": "Runs queue gate and lane planning only, classifies PRs and issues, and stops before edits, comments, pushes, or merges.",
+      "category": "positive-plan-only",
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add local-only trigger eval fixtures for `threads` boundary cases in the `skill-creator/scripts/run_eval.py` schema: a top-level array with `query` and `should_trigger`.
- Cover positive Codex-native subagent, GitHub queue, review-only, research/spec, Chinese subagent, and plan-only prompts.
- Cover negative OS/language concurrency, discussion/email threads, Assistants API threads, and tiny single-agent tasks.
- Add a short `SKILL.md` pointer to the fixtures while keeping the router under the length-warning threshold.

Closes #115.

## Base
- `origin/main`: `5ba135ecee94732e9f078858b0bdad47f64d09f9`

## Verification
- `python3 -m json.tool skills/threads/evals/evals.json >/dev/null`
- runner-field check: all 12 cases have `query` and boolean `should_trigger`
- `wc -l skills/threads/evals/evals.json skills/threads/SKILL.md` -> `122` and `498`
- `python3 scripts/validate_skills.py --check`
- `python3 scripts/audit_skill_quality.py threads`
- `python3 -m unittest tests.test_threads_run_log -q`
- `python3 -m unittest discover -s tests -q`
- `git diff --check`

## Threads Evidence
- Queue gate thread: `019f02f8-b5b9-7ce2-b4cc-d71b0d6cf0e3`
- Coordinator selected #115 as the next independent issue tranche after resolving PR #120 review threads and closing stale #114.
