### PR TITLE
feat(threads): add run log analysis helper

### DIFF
--- a/skills/threads/scripts/analyze_run_log.py
+++ b/skills/threads/scripts/analyze_run_log.py
@@ -10,7 +10,7 @@ from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from append_run_log import default_log_path
+from append_run_log import default_log_path, nested_get, valid_spawned_agents
 
 
 JSONValue = None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
@@ -66,23 +66,15 @@ def _native_evidence(record: JSONObject) -> JSONObject:
 
 
 def _spawned_agents(record: JSONObject) -> list[JSONObject]:
-    agents = _as_list(_native_evidence(record).get("spawned_agents"))
-    return [agent for agent in agents if isinstance(agent, dict)]
+    return valid_spawned_agents(record)
 
 
 def _explicit_thread_request(record: JSONObject) -> bool:
-    if _truthy(record.get("explicit_thread_request")):
-        return True
-    gate = _as_object(record.get("thread_dispatch_gate"))
-    return _truthy(gate.get("explicit_thread_request"))
+    return _truthy(nested_get(record, "explicit_thread_request"))
 
 
 def _fallback_mode(record: JSONObject) -> str | None:
-    fallback = _string(record.get("fallback_mode"))
-    if fallback:
-        return fallback
-    gate = _as_object(record.get("thread_dispatch_gate"))
-    return _string(gate.get("fallback_mode"))
+    return _string(nested_get(record, "fallback_mode"))
 
 
 def _stale_base(record: JSONObject) -> bool:
@@ -90,11 +82,13 @@ def _stale_base(record: JSONObject) -> bool:
     remote_truth = _as_object(record.get("remote_truth"))
     queue_gate = _as_object(record.get("queue_gate"))
     queue_remote_refresh = _as_object(queue_gate.get("remote_refresh"))
+    queue_ledger = _as_object(record.get("queue_ledger"))
     failure_codes = [code for code in _as_list(record.get("failure_codes")) if isinstance(code, str)]
     return (
         _truthy(remote_refresh.get("stale_base"))
         or _truthy(remote_truth.get("stale_base"))
         or _truthy(queue_remote_refresh.get("stale_base"))
+        or _truthy(queue_ledger.get("stale_base"))
         or "stale_base" in failure_codes
     )
 
@@ -103,11 +97,12 @@ def _durable_log_gap(record: JSONObject) -> bool:
     run_log = _as_object(record.get("run_log"))
     write_status = _string(run_log.get("write_status"))
     no_log_reason = _string(run_log.get("no_log_reason"))
-    if write_status and write_status != "written":
+    failure_codes = [code for code in _as_list(record.get("failure_codes")) if isinstance(code, str)]
+    if "durable_log_skipped" in failure_codes:
         return True
-    if no_log_reason:
+    if write_status in {"failed", "error", "skipped"}:
         return True
-    return "durable_log_skipped" in [code for code in _as_list(record.get("failure_codes")) if isinstance(code, str)]
+    return write_status == "not_written" and no_log_reason is None
 
 
 def _read_records(path: Path) -> tuple[list[JSONObject], int]:

--- a/skills/threads/scripts/analyze_run_log.py
+++ b/skills/threads/scripts/analyze_run_log.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Summarize local threads run-log JSONL without exposing raw prompts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from append_run_log import default_log_path
+
+
+JSONValue = None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
+JSONObject = dict[str, JSONValue]
+
+
+@dataclass
+class RunLogSummary:
+    path: str
+    path_exists: bool
+    records_total: int = 0
+    invalid_lines: int = 0
+    failure_codes: Counter[str] = field(default_factory=Counter)
+    truth_levels: Counter[str] = field(default_factory=Counter)
+    modes: Counter[str] = field(default_factory=Counter)
+    outcomes: Counter[str] = field(default_factory=Counter)
+    repos: Counter[str] = field(default_factory=Counter)
+    explicit_thread_requests: int = 0
+    runs_with_spawned_agents: int = 0
+    spawned_agents_total: int = 0
+    single_agent_fallbacks: int = 0
+    stale_base_events: int = 0
+    durable_log_gaps: int = 0
+    missing_log_file: bool = False
+
+
+def _as_object(value: JSONValue | None) -> JSONObject:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: JSONValue | None) -> list[JSONValue]:
+    return value if isinstance(value, list) else []
+
+
+def _truthy(value: JSONValue | None) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"yes", "true", "1", "required"}
+    return False
+
+
+def _string(value: JSONValue | None) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _native_evidence(record: JSONObject) -> JSONObject:
+    evidence = _as_object(record.get("native_thread_evidence"))
+    if evidence:
+        return evidence
+    gate = _as_object(record.get("thread_dispatch_gate"))
+    return _as_object(gate.get("native_thread_evidence"))
+
+
+def _spawned_agents(record: JSONObject) -> list[JSONObject]:
+    agents = _as_list(_native_evidence(record).get("spawned_agents"))
+    return [agent for agent in agents if isinstance(agent, dict)]
+
+
+def _explicit_thread_request(record: JSONObject) -> bool:
+    if _truthy(record.get("explicit_thread_request")):
+        return True
+    gate = _as_object(record.get("thread_dispatch_gate"))
+    return _truthy(gate.get("explicit_thread_request"))
+
+
+def _fallback_mode(record: JSONObject) -> str | None:
+    fallback = _string(record.get("fallback_mode"))
+    if fallback:
+        return fallback
+    gate = _as_object(record.get("thread_dispatch_gate"))
+    return _string(gate.get("fallback_mode"))
+
+
+def _stale_base(record: JSONObject) -> bool:
+    remote_refresh = _as_object(record.get("remote_refresh"))
+    remote_truth = _as_object(record.get("remote_truth"))
+    queue_gate = _as_object(record.get("queue_gate"))
+    queue_remote_refresh = _as_object(queue_gate.get("remote_refresh"))
+    failure_codes = [code for code in _as_list(record.get("failure_codes")) if isinstance(code, str)]
+    return (
+        _truthy(remote_refresh.get("stale_base"))
+        or _truthy(remote_truth.get("stale_base"))
+        or _truthy(queue_remote_refresh.get("stale_base"))
+        or "stale_base" in failure_codes
+    )
+
+
+def _durable_log_gap(record: JSONObject) -> bool:
+    run_log = _as_object(record.get("run_log"))
+    write_status = _string(run_log.get("write_status"))
+    no_log_reason = _string(run_log.get("no_log_reason"))
+    if write_status and write_status != "written":
+        return True
+    if no_log_reason:
+        return True
+    return "durable_log_skipped" in [code for code in _as_list(record.get("failure_codes")) if isinstance(code, str)]
+
+
+def _read_records(path: Path) -> tuple[list[JSONObject], int]:
+    records: list[JSONObject] = []
+    if not path.exists():
+        return records, 0
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                raise ValueError(f"{path}:{line_number}: invalid JSONL record")
+            if isinstance(parsed, dict):
+                records.append(parsed)
+            else:
+                raise ValueError(f"{path}:{line_number}: JSONL record must be an object")
+    return records, 0
+
+
+def summarize(path: Path) -> RunLogSummary:
+    records, invalid = _read_records(path)
+    summary = RunLogSummary(
+        path=str(path),
+        path_exists=path.exists(),
+        records_total=len(records),
+        invalid_lines=invalid,
+        missing_log_file=not path.exists(),
+    )
+    for record in records:
+        for field_name, counter in (
+            ("truth_level", summary.truth_levels),
+            ("mode", summary.modes),
+            ("outcome", summary.outcomes),
+            ("repo", summary.repos),
+        ):
+            value = _string(record.get(field_name))
+            if value:
+                counter[value] += 1
+        for code in _as_list(record.get("failure_codes")):
+            if isinstance(code, str) and code:
+                summary.failure_codes[code] += 1
+        if _explicit_thread_request(record):
+            summary.explicit_thread_requests += 1
+        spawned = _spawned_agents(record)
+        if spawned:
+            summary.runs_with_spawned_agents += 1
+            summary.spawned_agents_total += len(spawned)
+        if _fallback_mode(record) == "single_agent":
+            summary.single_agent_fallbacks += 1
+        if _stale_base(record):
+            summary.stale_base_events += 1
+        if _durable_log_gap(record):
+            summary.durable_log_gaps += 1
+    return summary
+
+
+def _top(counter: Counter[str], limit: int) -> list[dict[str, int | str]]:
+    return [{"name": name, "count": count} for name, count in counter.most_common(limit)]
+
+
+def to_json(summary: RunLogSummary, limit: int) -> str:
+    payload = {
+        "path": summary.path,
+        "status": "missing" if summary.missing_log_file else "ok",
+        "missing_files": [summary.path] if summary.missing_log_file else [],
+        "records_total": summary.records_total,
+        "invalid_lines": summary.invalid_lines,
+        "failure_codes": _top(summary.failure_codes, limit),
+        "truth_levels": dict(summary.truth_levels),
+        "modes": dict(summary.modes),
+        "outcomes": dict(summary.outcomes),
+        "repos": _top(summary.repos, limit),
+        "stale_base_events": summary.stale_base_events,
+        "durable_log_gaps": summary.durable_log_gaps,
+        "native_spawn_evidence": {
+            "explicit_thread_requests": summary.explicit_thread_requests,
+            "runs_with_spawned_agents": summary.runs_with_spawned_agents,
+            "spawned_agents_total": summary.spawned_agents_total,
+            "single_agent_fallbacks": summary.single_agent_fallbacks,
+        },
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _format_counter(counter: Counter[str], limit: int) -> list[str]:
+    if not counter:
+        return ["  none"]
+    return [f"  {name}: {count}" for name, count in counter.most_common(limit)]
+
+
+def to_text(summary: RunLogSummary, limit: int) -> str:
+    status = "missing" if summary.missing_log_file else "ok"
+    lines = [
+        "Threads run log summary",
+        f"path: {summary.path}",
+        f"status: {status}",
+        f"records: {summary.records_total}",
+        f"invalid_lines: {summary.invalid_lines}",
+    ]
+    if summary.missing_log_file:
+        lines.append("note: no durable threads run log found; pass --path or set CODEX_THREADS_RUN_LOG")
+    lines.extend([
+        "truth_levels:",
+        *_format_counter(summary.truth_levels, limit),
+        "failure_codes:",
+        *_format_counter(summary.failure_codes, limit),
+        f"stale_base_events: {summary.stale_base_events}",
+        f"durable_log_gaps: {summary.durable_log_gaps}",
+        "native_spawn_evidence:",
+        f"  explicit_thread_requests: {summary.explicit_thread_requests}",
+        f"  runs_with_spawned_agents: {summary.runs_with_spawned_agents}",
+        f"  spawned_agents_total: {summary.spawned_agents_total}",
+        f"  single_agent_fallbacks: {summary.single_agent_fallbacks}",
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--path", type=Path, default=None, help="JSONL path; defaults to the threads run-log path")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument("--limit", type=int, default=20, help="Maximum rows per counted section")
+    args = parser.parse_args()
+
+    path = args.path.expanduser() if args.path is not None else default_log_path()
+    try:
+        summary = summarize(path)
+    except ValueError as exc:
+        sys.stderr.write(f"analyze_run_log.py: {exc}\n")
+        return 1
+    limit = max(1, args.limit)
+    if args.format == "json":
+        sys.stdout.write(to_json(summary, limit))
+    else:
+        sys.stdout.write(to_text(summary, limit))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_threads_analyze_run_log.py
+++ b/tests/test_threads_analyze_run_log.py
@@ -55,6 +55,9 @@ class ThreadsAnalyzeRunLogTests(unittest.TestCase):
                                 "lane_id": "review-pr",
                                 "spawn_tool": "multi_agent_v1.spawn_agent",
                                 "agent_id_or_thread_id": "agent-123",
+                                "result_collected": True,
+                                "wait_evidence": "wait_agent completed",
+                                "close_evidence": "close_agent completed",
                             }
                         ]
                     },
@@ -90,6 +93,43 @@ class ThreadsAnalyzeRunLogTests(unittest.TestCase):
             self.assertIn("runs_with_spawned_agents: 1", result.stdout)
             self.assertIn("spawned_agents_total: 1", result.stdout)
             self.assertIn("single_agent_fallbacks: 1", result.stdout)
+
+    def test_matches_writer_spawn_and_gate_semantics(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "run-log.jsonl"
+            records = [
+                {
+                    "skill": "threads",
+                    "mode": "review_only",
+                    "capability_gate": {"explicit_thread_request": True},
+                    "native_thread_evidence": {
+                        "spawned_agents": [
+                            {
+                                "lane_id": "placeholder",
+                                "spawn_tool": "manual",
+                                "agent_id_or_thread_id": "none",
+                                "result_collected": False,
+                            }
+                        ]
+                    },
+                },
+                {
+                    "skill": "threads",
+                    "mode": "execute_direct",
+                    "queue_ledger": {"stale_base": True},
+                    "run_log": {"write_status": "not_applicable"},
+                },
+            ]
+            log_path.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
+
+            result = self.run_script(log_path)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("explicit_thread_requests: 1", result.stdout)
+            self.assertIn("runs_with_spawned_agents: 0", result.stdout)
+            self.assertIn("spawned_agents_total: 0", result.stdout)
+            self.assertIn("stale_base_events: 1", result.stdout)
+            self.assertIn("durable_log_gaps: 0", result.stdout)
 
     def test_json_output_is_structured_and_private(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_threads_analyze_run_log.py
+++ b/tests/test_threads_analyze_run_log.py
@@ -1,0 +1,128 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "skills" / "threads" / "scripts" / "analyze_run_log.py"
+
+
+class ThreadsAnalyzeRunLogTests(unittest.TestCase):
+    def run_script(self, log_path, *extra_args):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--path", str(log_path), *extra_args],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_missing_log_file_returns_clear_empty_report(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "missing.jsonl"
+
+            result = self.run_script(log_path)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("status: missing", result.stdout)
+            self.assertIn("records: 0", result.stdout)
+            self.assertIn("no durable threads run log found", result.stdout)
+
+            json_result = self.run_script(log_path, "--format", "json")
+            self.assertEqual(json_result.returncode, 0, json_result.stderr)
+            payload = json.loads(json_result.stdout)
+            self.assertEqual(payload["status"], "missing")
+            self.assertEqual(payload["missing_files"], [str(log_path)])
+            self.assertEqual(payload["records_total"], 0)
+
+    def test_summarizes_failure_codes_stale_base_and_native_spawn(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "run-log.jsonl"
+            records = [
+                {
+                    "skill": "threads",
+                    "mode": "execute_direct",
+                    "truth_level": "A",
+                    "failure_codes": ["review_thread_missed", "stale_base"],
+                    "queue_gate": {"remote_refresh": {"stale_base": True}},
+                    "explicit_thread_request": True,
+                    "fallback_mode": "none",
+                    "native_thread_evidence": {
+                        "spawned_agents": [
+                            {
+                                "lane_id": "review-pr",
+                                "spawn_tool": "multi_agent_v1.spawn_agent",
+                                "agent_id_or_thread_id": "agent-123",
+                            }
+                        ]
+                    },
+                    "run_log": {"write_status": "written"},
+                    "outcome": "partial",
+                    "repo": "/repo",
+                },
+                {
+                    "skill": "threads",
+                    "mode": "review_only",
+                    "truth_level": "B",
+                    "failure_codes": ["durable_log_skipped"],
+                    "thread_dispatch_gate": {
+                        "explicit_thread_request": True,
+                        "fallback_mode": "single_agent",
+                    },
+                    "run_log": {"write_status": "not_written", "no_log_reason": "user opt out"},
+                    "outcome": "blocked",
+                    "repo": "/repo",
+                },
+            ]
+            log_path.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
+
+            result = self.run_script(log_path)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("records: 2", result.stdout)
+            self.assertIn("invalid_lines: 0", result.stdout)
+            self.assertIn("review_thread_missed: 1", result.stdout)
+            self.assertIn("durable_log_skipped: 1", result.stdout)
+            self.assertIn("stale_base_events: 1", result.stdout)
+            self.assertIn("durable_log_gaps: 1", result.stdout)
+            self.assertIn("runs_with_spawned_agents: 1", result.stdout)
+            self.assertIn("spawned_agents_total: 1", result.stdout)
+            self.assertIn("single_agent_fallbacks: 1", result.stdout)
+
+    def test_json_output_is_structured_and_private(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "run-log.jsonl"
+            log_path.write_text(json.dumps({
+                "skill": "threads",
+                "mode": "plan_only",
+                "truth_level": "C",
+                "trigger_summary": "raw prompt should not appear",
+                "notes": "private details should not appear",
+            }) + "\n", encoding="utf-8")
+
+            result = self.run_script(log_path, "--format", "json")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["records_total"], 1)
+            self.assertEqual(payload["truth_levels"], {"C": 1})
+            self.assertEqual(payload["missing_files"], [])
+            self.assertNotIn("raw prompt", result.stdout)
+            self.assertNotIn("private details", result.stdout)
+
+    def test_corrupt_jsonl_fails_clearly(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "run-log.jsonl"
+            log_path.write_text(json.dumps({"skill": "threads"}) + "\nnot-json\n", encoding="utf-8")
+
+            result = self.run_script(log_path)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("invalid JSONL record", result.stderr)
+            self.assertIn("run-log.jsonl:2", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a read-only `threads` run-log analyzer for local JSONL summaries.
- Report failure-code counts, truth-level distribution, stale-base events, durable-log gaps, and native-spawn evidence.
- Keep missing log files safe with an empty report, and fail clearly on corrupt JSONL.
- Avoid printing raw prompts, notes, command output, or full records.

Closes #116.

## Base
- `origin/main`: `5ba135ecee94732e9f078858b0bdad47f64d09f9`

## Verification
- `python3 -m py_compile skills/threads/scripts/append_run_log.py skills/threads/scripts/analyze_run_log.py`
- `python3 -m unittest tests.test_threads_analyze_run_log -q`
- `python3 -m unittest tests.test_threads_run_log -q`
- `python3 -m unittest discover -s tests -q`
- `python3 scripts/validate_skills.py --check`
- `python3 scripts/audit_skill_quality.py threads`
- `python3 skills/threads/scripts/analyze_run_log.py --path /tmp/nonexistent-threads-run-log.jsonl`
- `python3 skills/threads/scripts/analyze_run_log.py --path /tmp/nonexistent-threads-run-log.jsonl --format json | python3 -m json.tool >/dev/null`
- `git diff --check`

## Threads Evidence
- Queue gate thread: `019f02f8-b5b9-7ce2-b4cc-d71b0d6cf0e3`
- Issue #116 planner lane: `019f0304-1af3-71e1-9e6f-cacc22c3df45`
- Planner confirmed no hard dependency on draft PR #119 when #116 stays a standalone read-only analyzer and avoids writer/schema changes.
