### PR TITLE
Harden threads context handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,19 @@ short: path-scoped `AGENTS.md` files carry directory-specific rules.
   blocker.
 - Never commit secrets, tokens, private keys, or credential material.
 
+## Threads Long-Run Guardrails
+
+- Generic context-budget and output-firewall policy for Codex subagent
+  orchestration belongs in `skills/threads/`; repository-specific queue policy
+  belongs in the consumer workflow pack.
+- For long queues or multi-lane runs, keep parent context thin: raw logs, broad
+  searches, CI output, and session JSONL must go to artifacts or stay out of
+  parent context.
+- `threads` run-log schema, `SKILL.md`, and `references/run-log.md` must stay in
+  sync when adding fields, failure codes, or lane contracts.
+- Installed copies under `~/.agents/skills/threads` and `~/.spellbook/skills/threads`
+  should be synced and hash-checked when local runtime behavior matters.
+
 ## Validation
 
 - Skill, registry, install, or README count changes:

--- a/skills/threads/SKILL.md
+++ b/skills/threads/SKILL.md
@@ -15,11 +15,12 @@ Native Codex threads are short-lived parallel work lines inside the Codex workfl
 1. Classify the request: `single_agent`, `plan_only`, `execute_direct`, `review_only`, `research_spec`, or `clarify_first`.
 2. If the user explicitly asked for threads, record `thread_dispatch_gate` and spawn required native lanes before implementation.
 3. For GitHub queues, fetch remote state in the coordinator lane, then write `queue_gate`, `queue_ledger`, and `issue_to_pr_map`.
-4. Write a lane map with file ownership, verification owner, and stop conditions.
-5. Dispatch only bounded native lanes with disjoint writable scopes or read-only roles.
-6. Collect, wait, and close spawned agents; do not count the coordinator as a spawned thread.
-7. Run fresh verification tied to the current head or artifact.
-8. End with a compact final report and `threads_run_log`; write durable JSONL for queue, multi-lane, push, comment, or merge-capable runs.
+4. Write a lane map with file ownership, verification owner, stop conditions, context budget, and output firewall.
+5. Route large command output to artifacts before dispatch; the parent reads only summaries, short tails, targeted greps, and evidence paths.
+6. Dispatch only bounded native lanes with disjoint writable scopes or read-only roles.
+7. Collect, wait, and close spawned agents; do not count the coordinator as a spawned thread.
+8. Run fresh verification tied to the current head or artifact.
+9. End with a compact final report and `threads_run_log`; write durable JSONL for queue, multi-lane, push, comment, or merge-capable runs.
 
 ## Do Not Use For
 
@@ -107,6 +108,17 @@ intent_contract:
     max_items:
     time_budget:
     queue_tranche:
+  context_budget:
+    window_tokens:
+    soft_stop_ratio:
+    hard_stop_ratio:
+    critical_stop_ratio:
+    current_usage_signal:
+  output_firewall:
+    raw_log_policy: file_only | summary_only | not_applicable
+    max_parent_stdout_lines:
+    max_subagent_final_lines:
+    artifact_root:
   remote_refresh:
     cadence:
     last_fetch:
@@ -135,6 +147,53 @@ Feedback loop: record notable failures in `threads_run_log`, classify the failur
 If the user asks for issue/PR queue handling, `remote_truth_required` is `yes` and `queue_ledger` is `required_for_queue`.
 
 Broad queue requests such as "all issues and PRs" are bounded by default. If the user did not give an explicit long-run budget, choose one smallest mergeable tranche, record `max_items` / `time_budget` / `queue_tranche`, and leave the remaining queue for the next run with exact next actions.
+
+## Parent Context Budget
+
+For long queues, multi-lane runs, CI polling, or any run likely to carry large logs, record a parent context budget before dispatch:
+
+```text
+context_budget:
+- window_tokens:
+- soft_stop_ratio: 0.50
+- hard_stop_ratio: 0.65
+- critical_stop_ratio: 0.75
+- current_usage_signal:
+- override_reason:
+```
+
+Defaults are guidance, not universal limits. Override them when the model window, task size, or user budget requires it, but record the override.
+
+Rules:
+
+- At `soft_stop`, do not spawn new lanes, broaden queue scope, or run broad discovery. Finish the current bounded lane and use targeted reads only.
+- At `hard_stop`, stop expanding work, collect current lane evidence, write or update the queue ledger/run log, and hand off to a fresh parent thread.
+- At `critical_stop`, do not read large files, raw logs, broad search results, or historical transcripts. Write the minimum handoff/resume prompt and stop.
+- Do not treat old parent transcripts, raw Codex session JSONL, or compaction summaries as live queue state. Use current repo/GitHub truth plus durable ledgers or artifacts.
+- For long issue/PR queues, a fresh parent per bounded tranche is the default recovery path, not a failure.
+
+## Output Firewall
+
+Large-output commands are allowed only when raw stdout/stderr are written to artifact files outside the parent transcript:
+
+```text
+output_firewall:
+- raw_log_policy: file_only
+- max_parent_stdout_lines: 150
+- max_subagent_final_lines: 150
+- artifact_root:
+- evidence_paths:
+```
+
+Parent-visible output should be limited to exit code, command name, short tail, targeted grep result, failure summary, and artifact path.
+
+Rules:
+
+- Do not paste raw `gh run view --log`, full workspace test output, broad `rg`/`git grep` results, long diffs, copied source files, or session JSONL into the parent.
+- Redirect large commands such as full local test suites, CI logs, or wide searches to files under the run's artifact root, then read only the bounded summary needed for the next decision.
+- Bound searches by path and exclude `.codex`, `.claude`, `target`, `node_modules`, session JSONL, and log files unless the user explicitly asks for forensic analysis.
+- Worker and reviewer lanes must return findings and evidence paths, not raw logs.
+- If raw output enters the parent and materially increases context risk, record `raw_output_blocked` or `parent_context_hard_stop` in `threads_run_log` and hand off if needed.
 
 ## Capability Gate
 
@@ -366,7 +425,7 @@ Use native subagents when available. If the multi-agent tool is not loaded, sear
 
 When `multi_agent_v1` tools are available, use `spawn_agent` for required bounded sidecar lanes, `wait_agent` only when the next critical-path step needs that result, and `close_agent` after collecting completed output. Keep immediate blockers in the main thread, but do not count the main thread as a spawned native thread.
 
-Close completed subagents as soon as their evidence has been collected. For long issue/PR queues, finish a bounded tranche, record the ledger and resume query, and consider starting a fresh parent thread instead of carrying oversized context forward.
+Close completed subagents as soon as their evidence has been collected. For long issue/PR queues, finish a bounded tranche, record the ledger and resume query, and start a fresh parent thread when the context budget is near or past the hard stop instead of carrying oversized context forward.
 
 Use these lane types:
 
@@ -389,10 +448,14 @@ files_read:
 files_changed:
 unauthorized_or_unassigned_changes:
 commands_run:
+output_summary:
+evidence_paths:
 head_sha_or_artifact:
 native_thread_id:
 blockers:
 ```
+
+Lane outputs must not include raw logs, long diffs, copied source files, broad search dumps, or full command output. If the lane produced large evidence, it must return the artifact path plus the smallest useful summary.
 
 ## Merge Gate
 
@@ -472,6 +535,13 @@ threads_run_log:
 - queue_items_total:
 - queue_bounds:
     queue_tranche:
+- context_budget:
+    soft_stop_ratio:
+    hard_stop_ratio:
+    critical_stop_ratio:
+- output_firewall:
+    raw_log_policy:
+    artifact_root:
 - failure_codes:
 - verification:
     fresh:

--- a/skills/threads/references/run-log.md
+++ b/skills/threads/references/run-log.md
@@ -82,12 +82,29 @@ python3 "$THREADS_SKILL_DIR/scripts/append_run_log.py" <<'JSON'
     "time_budget": "30m",
     "queue_tranche": "first merge-ready blocker"
   },
+  "context_budget": {
+    "window_tokens": 258400,
+    "soft_stop_ratio": 0.5,
+    "hard_stop_ratio": 0.65,
+    "critical_stop_ratio": 0.75,
+    "current_usage_signal": "below_soft_stop"
+  },
+  "output_firewall": {
+    "raw_log_policy": "file_only",
+    "max_parent_stdout_lines": 150,
+    "max_subagent_final_lines": 150,
+    "artifact_root": "artifacts/logs/tranche-001",
+    "evidence_paths": ["artifacts/logs/tranche-001/cargo-test.log"]
+  },
   "lanes_total": 4,
   "failure_codes": ["review_thread_missed"],
   "remote_refresh": {
+    "owner_lane": "coordinator",
     "origin_main_sha": "abc123",
+    "local_base_sha": "abc123",
     "stale_base": false,
-    "refreshes": 3
+    "refreshes": 3,
+    "policy": "continue"
   },
   "remote_truth": {
     "open_prs": 0,
@@ -157,6 +174,21 @@ Recommended fields:
     "max_items": 1,
     "time_budget": "30m",
     "queue_tranche": "first blocker"
+  },
+  "context_budget": {
+    "window_tokens": 258400,
+    "soft_stop_ratio": 0.5,
+    "hard_stop_ratio": 0.65,
+    "critical_stop_ratio": 0.75,
+    "current_usage_signal": "below_soft_stop",
+    "override_reason": ""
+  },
+  "output_firewall": {
+    "raw_log_policy": "file_only",
+    "max_parent_stdout_lines": 150,
+    "max_subagent_final_lines": 150,
+    "artifact_root": "artifacts/logs/tranche-001",
+    "evidence_paths": []
   },
   "remote_refresh": {
     "owner_lane": "coordinator",
@@ -292,6 +324,8 @@ Use stable codes so later analysis can aggregate them:
 - `write_scope_violation`: worker touched unassigned or forbidden files.
 - `vague_lane_output`: lane returned claims without commands, files, or evidence.
 - `verification_gap`: completion was claimed without fresh command output.
+- `raw_output_blocked`: raw logs, long command output, broad search output, or session JSONL attempted to enter the parent instead of an artifact.
+- `parent_context_hard_stop`: parent context budget hit the hard or critical stop and the run had to checkpoint or hand off.
 - `review_thread_missed`: inline review thread/comment state was not checked.
 - `connector_review_incomplete`: a requested or expected GitHub/Codex connector review was not complete on the current head.
 - `review_loop`: repeated review-thread fix cycles hit the configured limit.
@@ -316,4 +350,4 @@ test -f "$LOG" && jq -r 'select(.verification.fresh==false) | [.recorded_at_utc,
 
 ## Privacy
 
-Do not log secrets, tokens, cookies, private messages, raw prompts, or full command output. Log concise summaries and stable evidence identifiers instead: file paths, command names, PR/issue numbers, head SHAs, and failure codes. Unknown top-level fields are rejected unless `--allow-extra` is supplied.
+Do not log secrets, tokens, cookies, private messages, raw prompts, raw session JSONL, or full command output. Log concise summaries and stable evidence identifiers instead: file paths, command names, PR/issue numbers, head SHAs, artifact paths, and failure codes. Unknown top-level fields are rejected unless `--allow-extra` is supplied.

--- a/skills/threads/scripts/run_log_schema.py
+++ b/skills/threads/scripts/run_log_schema.py
@@ -276,11 +276,10 @@ def validate_string_list(value: Any, field: str) -> None:
             raise ValueError(f"{field} entries must be non-empty strings")
 
 
-def validate_context_budget(record: dict[str, Any]) -> None:
-    context_budget = record.get("context_budget")
+def validate_context_budget_object(context_budget: Any, field_prefix: str) -> None:
     if context_budget is None:
         return
-    budget = require_object(context_budget, "context_budget")
+    budget = require_object(context_budget, field_prefix)
     for field in (
         "window_tokens",
         "soft_stop_ratio",
@@ -288,38 +287,57 @@ def validate_context_budget(record: dict[str, Any]) -> None:
         "critical_stop_ratio",
     ):
         if field not in budget:
-            raise ValueError(f"context_budget.{field} is required when context_budget is present")
-    validate_positive_int(budget.get("window_tokens"), "context_budget.window_tokens")
+            raise ValueError(f"{field_prefix}.{field} is required when {field_prefix} is present")
+    validate_positive_int(budget.get("window_tokens"), f"{field_prefix}.window_tokens")
     for field in ("soft_stop_ratio", "hard_stop_ratio", "critical_stop_ratio"):
-        validate_ratio(budget[field], f"context_budget.{field}")
+        validate_ratio(budget[field], f"{field_prefix}.{field}")
     soft = budget["soft_stop_ratio"]
     hard = budget["hard_stop_ratio"]
     critical = budget["critical_stop_ratio"]
     if not soft < hard < critical:
         raise ValueError(
-            "context_budget ratios must satisfy soft_stop_ratio < "
+            f"{field_prefix} ratios must satisfy soft_stop_ratio < "
             "hard_stop_ratio < critical_stop_ratio"
         )
 
 
-def validate_output_firewall(record: dict[str, Any]) -> None:
-    output_firewall = record.get("output_firewall")
+def validate_context_budget(record: dict[str, Any]) -> None:
+    validate_context_budget_object(record.get("context_budget"), "context_budget")
+    intent_contract = record.get("intent_contract")
+    if isinstance(intent_contract, dict):
+        validate_context_budget_object(
+            intent_contract.get("context_budget"),
+            "intent_contract.context_budget",
+        )
+
+
+def validate_output_firewall_object(output_firewall: Any, field_prefix: str) -> None:
     if output_firewall is None:
         return
-    firewall = require_object(output_firewall, "output_firewall")
+    firewall = require_object(output_firewall, field_prefix)
     if "raw_log_policy" not in firewall:
-        raise ValueError("output_firewall.raw_log_policy is required when output_firewall is present")
+        raise ValueError(f"{field_prefix}.raw_log_policy is required when {field_prefix} is present")
     validate_enum(
         firewall.get("raw_log_policy"),
         ALLOWED_RAW_LOG_POLICIES,
-        "output_firewall.raw_log_policy",
+        f"{field_prefix}.raw_log_policy",
     )
     for field in ("max_parent_stdout_lines", "max_subagent_final_lines"):
-        validate_non_negative_int(firewall.get(field), f"output_firewall.{field}")
+        validate_non_negative_int(firewall.get(field), f"{field_prefix}.{field}")
     if firewall.get("raw_log_policy") == "file_only":
-        validate_non_empty_string(firewall.get("artifact_root"), "output_firewall.artifact_root")
+        validate_non_empty_string(firewall.get("artifact_root"), f"{field_prefix}.artifact_root")
     if "evidence_paths" in firewall:
-        validate_string_list(firewall["evidence_paths"], "output_firewall.evidence_paths")
+        validate_string_list(firewall["evidence_paths"], f"{field_prefix}.evidence_paths")
+
+
+def validate_output_firewall(record: dict[str, Any]) -> None:
+    validate_output_firewall_object(record.get("output_firewall"), "output_firewall")
+    intent_contract = record.get("intent_contract")
+    if isinstance(intent_contract, dict):
+        validate_output_firewall_object(
+            intent_contract.get("output_firewall"),
+            "intent_contract.output_firewall",
+        )
 
 
 def validate_failure_codes(record: dict[str, Any]) -> None:

--- a/skills/threads/scripts/run_log_schema.py
+++ b/skills/threads/scripts/run_log_schema.py
@@ -16,6 +16,7 @@ SENSITIVE_KEY_PARTS = (
     "api_key",
     "apikey",
 )
+SAFE_TOKEN_FIELD_NAMES = {"window_tokens"}
 MAX_STRING_LENGTH = 4000
 MAX_INPUT_BYTES = 64 * 1024
 MAX_DEPTH = 8
@@ -68,6 +69,7 @@ ALLOWED_CONNECTOR_REVIEW_STATUSES = {
     "unknown",
 }
 ALLOWED_REVIEW_LOOP_OUTCOMES = {"resolved", "review_loop", "not_applicable"}
+ALLOWED_RAW_LOG_POLICIES = {"file_only", "summary_only", "not_applicable"}
 INVALID_AGENT_IDS = {"", "none", "n/a", "na", "null", "main", "main_thread", "coordinator"}
 ALLOWED_SINGLE_AGENT_REASONS = {
     "no_independent_lanes",
@@ -103,6 +105,8 @@ ALLOWED_TOP_LEVEL_FIELDS = {
     "thread_dispatch_gate",
     "queue_gate",
     "queue_bounds",
+    "context_budget",
+    "output_firewall",
     "remote_refresh",
     "queue_ledger",
     "lane_map",
@@ -137,6 +141,8 @@ ALLOWED_FAILURE_CODES = {
     "write_scope_violation",
     "vague_lane_output",
     "verification_gap",
+    "raw_output_blocked",
+    "parent_context_hard_stop",
     "review_thread_missed",
     "connector_review_incomplete",
     "review_loop",
@@ -177,7 +183,10 @@ def redact(value: Any, key_hint: str = "", depth: int = 0) -> Any:
     if depth > MAX_DEPTH:
         return "[TRUNCATED_DEPTH]"
     lower_key = key_hint.lower()
-    if any(part in lower_key for part in SENSITIVE_KEY_PARTS):
+    if (
+        lower_key not in SAFE_TOKEN_FIELD_NAMES
+        and any(part in lower_key for part in SENSITIVE_KEY_PARTS)
+    ):
         return "[REDACTED]"
     if isinstance(value, dict):
         return {str(key): redact(item, str(key), depth + 1) for key, item in value.items()}
@@ -237,11 +246,80 @@ def validate_non_negative_int(value: Any, field: str) -> None:
         raise ValueError(f"{field} must be a non-negative integer")
 
 
+def validate_positive_int(value: Any, field: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field} must be a positive integer")
+
+
 def validate_non_negative_number(value: Any, field: str) -> None:
     if value is None:
         return
     if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
         raise ValueError(f"{field} must be a non-negative number")
+
+
+def validate_ratio(value: Any, field: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be a number")
+    if value <= 0 or value >= 1:
+        raise ValueError(f"{field} must be between 0 and 1")
+
+
+def validate_non_empty_string(value: Any, field: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+
+
+def validate_string_list(value: Any, field: str) -> None:
+    for item in require_list(value, field):
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{field} entries must be non-empty strings")
+
+
+def validate_context_budget(record: dict[str, Any]) -> None:
+    context_budget = record.get("context_budget")
+    if context_budget is None:
+        return
+    budget = require_object(context_budget, "context_budget")
+    for field in (
+        "window_tokens",
+        "soft_stop_ratio",
+        "hard_stop_ratio",
+        "critical_stop_ratio",
+    ):
+        if field not in budget:
+            raise ValueError(f"context_budget.{field} is required when context_budget is present")
+    validate_positive_int(budget.get("window_tokens"), "context_budget.window_tokens")
+    for field in ("soft_stop_ratio", "hard_stop_ratio", "critical_stop_ratio"):
+        validate_ratio(budget[field], f"context_budget.{field}")
+    soft = budget["soft_stop_ratio"]
+    hard = budget["hard_stop_ratio"]
+    critical = budget["critical_stop_ratio"]
+    if not soft < hard < critical:
+        raise ValueError(
+            "context_budget ratios must satisfy soft_stop_ratio < "
+            "hard_stop_ratio < critical_stop_ratio"
+        )
+
+
+def validate_output_firewall(record: dict[str, Any]) -> None:
+    output_firewall = record.get("output_firewall")
+    if output_firewall is None:
+        return
+    firewall = require_object(output_firewall, "output_firewall")
+    if "raw_log_policy" not in firewall:
+        raise ValueError("output_firewall.raw_log_policy is required when output_firewall is present")
+    validate_enum(
+        firewall.get("raw_log_policy"),
+        ALLOWED_RAW_LOG_POLICIES,
+        "output_firewall.raw_log_policy",
+    )
+    for field in ("max_parent_stdout_lines", "max_subagent_final_lines"):
+        validate_non_negative_int(firewall.get(field), f"output_firewall.{field}")
+    if firewall.get("raw_log_policy") == "file_only":
+        validate_non_empty_string(firewall.get("artifact_root"), "output_firewall.artifact_root")
+    if "evidence_paths" in firewall:
+        validate_string_list(firewall["evidence_paths"], "output_firewall.evidence_paths")
 
 
 def validate_failure_codes(record: dict[str, Any]) -> None:
@@ -298,6 +376,8 @@ def validate_enum_fields(record: dict[str, Any]) -> None:
     validate_connector_review(record)
     validate_ci_wait(record)
     validate_review_loop(record)
+    validate_context_budget(record)
+    validate_output_firewall(record)
     validate_failure_codes(record)
     validate_lanes(record)
 

--- a/tests/test_threads_run_log.py
+++ b/tests/test_threads_run_log.py
@@ -358,6 +358,29 @@ class ThreadsRunLogTests(unittest.TestCase):
 
         self.assert_rejects_payload(payload, "output_firewall.evidence_paths")
 
+    def test_rejects_intent_contract_context_budget_ratios_out_of_order(self):
+        payload = self.nested_payload()
+        payload["intent_contract"] = {
+            "context_budget": {
+                "window_tokens": 258400,
+                "soft_stop_ratio": 0.7,
+                "hard_stop_ratio": 0.65,
+                "critical_stop_ratio": 0.75,
+            }
+        }
+
+        self.assert_rejects_payload(payload, "intent_contract.context_budget ratios")
+
+    def test_rejects_intent_contract_output_firewall_policy(self):
+        payload = self.nested_payload()
+        payload["intent_contract"] = {
+            "output_firewall": {
+                "raw_log_policy": "paste_raw_logs",
+            }
+        }
+
+        self.assert_rejects_payload(payload, "intent_contract.output_firewall.raw_log_policy")
+
     def test_allows_legacy_queue_ledger_stale_base_record(self):
         with TemporaryDirectory() as temp_dir:
             log_path = Path(temp_dir) / "legacy-ledger.jsonl"

--- a/tests/test_threads_run_log.py
+++ b/tests/test_threads_run_log.py
@@ -281,6 +281,83 @@ class ThreadsRunLogTests(unittest.TestCase):
             self.assertEqual(record["queue_gate"]["issue_to_pr_map"][0]["status"], "uncovered")
             self.assertEqual(record["connector_review"]["status"], "no_connector_expected")
 
+    def test_allows_context_budget_and_output_firewall_fields(self):
+        with TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "context-firewall.jsonl"
+
+            result = self.run_script(
+                {
+                    "skill": "threads",
+                    "mode": "execute_direct",
+                    "context_budget": {
+                        "window_tokens": 258400,
+                        "soft_stop_ratio": 0.5,
+                        "hard_stop_ratio": 0.65,
+                        "critical_stop_ratio": 0.75,
+                        "current_usage_signal": "below_soft_stop",
+                    },
+                    "output_firewall": {
+                        "raw_log_policy": "file_only",
+                        "max_parent_stdout_lines": 150,
+                        "max_subagent_final_lines": 150,
+                        "artifact_root": "artifacts/logs/t01",
+                        "evidence_paths": ["artifacts/logs/t01/cargo-test.log"],
+                    },
+                    "failure_codes": ["raw_output_blocked", "parent_context_hard_stop"],
+                },
+                log_path,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            record = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+            self.assertEqual(record["output_firewall"]["raw_log_policy"], "file_only")
+            self.assertEqual(record["context_budget"]["hard_stop_ratio"], 0.65)
+
+    def test_rejects_context_budget_ratios_out_of_order(self):
+        payload = self.nested_payload()
+        payload["context_budget"] = {
+            "window_tokens": 258400,
+            "soft_stop_ratio": 0.7,
+            "hard_stop_ratio": 0.65,
+            "critical_stop_ratio": 0.75,
+        }
+
+        self.assert_rejects_payload(payload, "context_budget ratios")
+
+    def test_rejects_partial_context_budget(self):
+        payload = self.nested_payload()
+        payload["context_budget"] = {
+            "soft_stop_ratio": 0.5,
+            "hard_stop_ratio": 0.65,
+            "critical_stop_ratio": 0.75,
+        }
+
+        self.assert_rejects_payload(payload, "context_budget.window_tokens")
+
+    def test_rejects_unknown_output_firewall_policy(self):
+        payload = self.nested_payload()
+        payload["output_firewall"] = {"raw_log_policy": "paste_raw_logs"}
+
+        self.assert_rejects_payload(payload, "output_firewall.raw_log_policy")
+
+    def test_rejects_file_only_output_firewall_without_artifact_root(self):
+        payload = self.nested_payload()
+        payload["output_firewall"] = {
+            "raw_log_policy": "file_only",
+        }
+
+        self.assert_rejects_payload(payload, "output_firewall.artifact_root")
+
+    def test_rejects_non_string_output_firewall_evidence_path(self):
+        payload = self.nested_payload()
+        payload["output_firewall"] = {
+            "raw_log_policy": "file_only",
+            "artifact_root": "artifacts/logs/t01",
+            "evidence_paths": ["artifacts/logs/t01/cargo-test.log", 123],
+        }
+
+        self.assert_rejects_payload(payload, "output_firewall.evidence_paths")
+
     def test_allows_legacy_queue_ledger_stale_base_record(self):
         with TemporaryDirectory() as temp_dir:
             log_path = Path(temp_dir) / "legacy-ledger.jsonl"


### PR DESCRIPTION
## Summary
- add parent context budget and output firewall rules to the threads skill
- extend run-log docs and schema with context/output fields and failure codes
- tighten validation for partial budgets, file-only artifact roots, and evidence paths
- add AGENTS routing notes for generic threads long-run guardrails

## Verification
- python3 scripts/validate_skills.py --check
- python3 scripts/audit_skill_quality.py threads
- python3 -m unittest tests.test_threads_run_log tests.test_threads_run_log_dispatch tests.test_threads_analyze_run_log
- uvx --with pyyaml pytest -q
- git diff --check