### PR TITLE
test: cover repository skill sources

### DIFF
--- a/tests/test_skill_ecosystem_doctor.py
+++ b/tests/test_skill_ecosystem_doctor.py
@@ -179,6 +179,52 @@ class SkillEcosystemDoctorTests(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertIn("registry_projection_content_conflict", self.codes(result, "warning"))
 
+    def test_verified_canonical_path_classifies_inactive_source_variants(self):
+        self.write_skill(self.registry_skills, "shared", body="old registry version")
+        active = self.write_skill(self.codex, "shared", body="active version")
+        os.symlink(active, self.claude / "shared", target_is_directory=True)
+        self.write_governance(
+            skill_decisions=[
+                {
+                    "name": "shared",
+                    "decision": "keep",
+                    "reason": "The active reviewed source is canonical.",
+                    "owner": "runtime-owner",
+                    "canonical_path": str(active),
+                }
+            ]
+        )
+
+        result = self.validate()
+
+        self.assertTrue(result["ok"])
+        self.assertIn("declared_source_variant", self.codes(result, "info"))
+        self.assertNotIn(
+            "registry_projection_content_conflict",
+            self.codes(result, "warning"),
+        )
+
+    def test_unknown_decision_canonical_path_fails_closed(self):
+        self.write_skill(self.registry_skills, "shared")
+        self.write_governance(
+            skill_decisions=[
+                {
+                    "name": "shared",
+                    "decision": "keep",
+                    "reason": "Test fixture.",
+                    "owner": "runtime-owner",
+                    "canonical_path": str(self.base / "missing"),
+                }
+            ]
+        )
+
+        result = self.validate()
+
+        self.assertIn(
+            "skill_decision_canonical_path_missing",
+            self.codes(result, "error"),
+        )
+
     def test_broken_symlink_and_missing_resource_are_errors(self):
         missing_resource = self.write_skill(
             self.registry_skills,
@@ -223,7 +269,7 @@ class SkillEcosystemDoctorTests(unittest.TestCase):
         self.assertIn(str(wrong_type / "SKILL.md"), broken_paths)
         self.assertFalse(result["ok"])
 
-    def test_projection_directory_without_skill_md_is_an_error(self):
+    def test_skill_directory_without_skill_md_is_an_error(self):
         empty_projection = self.codex / "empty-projection"
         empty_projection.mkdir()
 
@@ -231,8 +277,8 @@ class SkillEcosystemDoctorTests(unittest.TestCase):
         linked_target.mkdir()
         os.symlink(linked_target, self.claude / "linked-empty", target_is_directory=True)
 
-        # Registry non-skill directories stay silent; only projections report.
-        (self.registry_skills / "not-a-skill-dir").mkdir()
+        empty_source = self.registry_skills / "not-a-skill-dir"
+        empty_source.mkdir()
 
         result = self.validate()
 
@@ -245,7 +291,90 @@ class SkillEcosystemDoctorTests(unittest.TestCase):
         self.assertEqual(len(broken), 2)
         self.assertIn(str(empty_projection), broken_paths)
         self.assertIn(str(self.claude / "linked-empty"), broken_paths)
+        missing_source = [
+            finding
+            for finding in result["findings"]
+            if finding["code"] == "skill_entrypoint_missing"
+        ]
+        self.assertEqual([finding["path"] for finding in missing_source], [str(empty_source)])
         self.assertFalse(result["ok"])
+
+    def test_additional_inventory_roots_are_scanned_with_declared_roles(self):
+        spellbook = self.base / "spellbook-skills"
+        agents = self.base / "agents-skills"
+        spellbook.mkdir()
+        agents.mkdir()
+        source = self.write_skill(spellbook, "source-only")
+        self.write_skill(agents, "managed-only")
+        self.write_governance(
+            source_policy={
+                "local_only_canonical_registry": str(self.registry),
+                "projection_roots": [str(self.codex), str(self.claude)],
+                "inventory_roots": [
+                    {
+                        "path": str(spellbook),
+                        "kind": "canonical_source",
+                        "owner": "spellbook",
+                    },
+                    {
+                        "path": str(agents),
+                        "kind": "managed_projection",
+                        "owner": "skill-installer",
+                    },
+                ],
+            }
+        )
+
+        result = self.validate()
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["summary"]["instances"], 2)
+        self.assertEqual(result["summary"]["declared_names"], 2)
+        self.assertEqual(result["roots"]["inventory"][0]["path"], str(spellbook))
+        self.assertNotIn("physical_projection_unpinned", self.codes(result))
+        self.assertTrue(source.is_dir())
+
+    def test_skill_decisions_must_cover_every_discovered_name(self):
+        self.write_skill(self.registry_skills, "classified")
+        self.write_skill(self.registry_skills, "unclassified")
+        self.write_governance(
+            skill_decisions=[
+                {
+                    "name": "classified",
+                    "decision": "keep",
+                    "reason": "Distinct tested capability.",
+                    "owner": "local-registry",
+                    "evidence": ["manual review"],
+                },
+                {
+                    "name": "future-name",
+                    "decision": "repair",
+                    "reason": "Expected source has not been restored.",
+                    "owner": "unresolved",
+                },
+            ]
+        )
+
+        result = self.validate()
+
+        self.assertIn("skill_decision_missing", self.codes(result, "error"))
+        self.assertIn("skill_decision_not_discovered", self.codes(result, "warning"))
+
+    def test_duplicate_or_invalid_skill_decisions_fail_closed(self):
+        duplicate = {
+            "name": "same",
+            "decision": "keep",
+            "reason": "Test fixture.",
+            "owner": "test",
+        }
+        self.write_governance(skill_decisions=[duplicate, duplicate])
+        with self.assertRaisesRegex(ValueError, "duplicate skill_decisions name: same"):
+            self.validate()
+
+        invalid = dict(duplicate, name="invalid", decision="delete-maybe")
+        self.write_governance(skill_decisions=[invalid])
+        with self.assertRaisesRegex(ValueError, r"skill_decisions\[0\]\.decision"):
+            self.validate()
 
     def test_all_supported_resource_paths_and_file_types_are_checked(self):
         references = (
@@ -549,6 +678,43 @@ class SkillEcosystemDoctorTests(unittest.TestCase):
         (installed / "references" / "threads.md").write_text("# Drift\n", encoding="utf-8")
         drifted = self.validate()
         self.assertIn("pinned_materialization_drift", self.codes(drifted, "error"))
+
+    def test_composite_mapping_satisfies_source_resource_reference(self):
+        source = self.write_skill(
+            self.registry_skills,
+            "composite-source",
+            body="Read [Threads](references/threads.md).",
+        )
+        shared_resource = self.base / "integrations" / "threads.md"
+        shared_resource.parent.mkdir()
+        shared_resource.write_text("# Threads\n", encoding="utf-8")
+        installed = self.write_skill(
+            self.codex,
+            "composite-source",
+            body="Read [Threads](references/threads.md).",
+            files={"references/threads.md": "# Threads\n"},
+        )
+        self.write_governance(
+            pinned_materializations=[
+                {
+                    "name": "composite-source",
+                    "path": str(installed),
+                    "source_path": str(source),
+                    "reason": "Installer-managed composite fixture.",
+                    "resource_mappings": [
+                        {
+                            "source_path": str(shared_resource),
+                            "destination_path": "references/threads.md",
+                        }
+                    ],
+                }
+            ]
+        )
+
+        result = self.validate()
+
+        self.assertTrue(result["ok"])
+        self.assertNotIn("missing_skill_resource", self.codes(result))
 
     def test_resource_mapping_cannot_source_from_projection(self):
         source_root = self.base / "independent-source"

--- a/tests/test_skill_ecosystem_repository_source.py
+++ b/tests/test_skill_ecosystem_repository_source.py
@@ -1,0 +1,199 @@
+"""Repository-style source coverage for Skill Ecosystem Doctor."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_DIR = ROOT / "skills" / "skill-ecosystem-doctor" / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import ecosystem_checks as validator
+
+
+def write_skill(path: Path, name: str, body: str = "") -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Use when testing repository sources.\n---\n{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+class RepositorySourceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.base = Path(self.tempdir.name)
+        self.registry = self.base / "registry"
+        self.registry.joinpath("skills").mkdir(parents=True)
+        self.codex = self.base / "codex"
+        self.codex.mkdir()
+        self.repository = self.base / "gstack"
+        self.governance = self.base / "governance.json"
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def validate(self, **overrides) -> dict:
+        policy = {
+            "schema_version": 1,
+            "source_policy": {
+                "local_only_canonical_registry": str(self.registry),
+                "projection_roots": [str(self.codex)],
+                "inventory_roots": [
+                    {
+                        "path": str(self.repository),
+                        "kind": "repository_source",
+                        "owner": "gstack",
+                    }
+                ],
+            },
+        }
+        policy.update(overrides)
+        self.governance.write_text(json.dumps(policy), encoding="utf-8")
+        return validator.validate_ecosystem(self.governance, run_loom=False)
+
+    def test_root_and_immediate_child_skills_are_discovered(self) -> None:
+        write_skill(self.repository, "gstack")
+        write_skill(self.repository / "ship", "ship")
+        (self.repository / "docs").mkdir()
+
+        result = self.validate()
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["summary"]["instances"], 2)
+        self.assertEqual(result["summary"]["declared_names"], 2)
+        self.assertEqual(result["findings"], [])
+
+    def test_root_entrypoint_is_required(self) -> None:
+        write_skill(self.repository / "ship", "ship")
+
+        result = self.validate()
+
+        self.assertFalse(result["ok"])
+        self.assertIn(
+            "skill_entrypoint_missing",
+            {finding["code"] for finding in result["findings"]},
+        )
+
+
+class ArchiveInventoryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.base = Path(self.tempdir.name)
+        self.registry = self.base / "registry"
+        self.registry.joinpath("skills").mkdir(parents=True)
+        self.runtime = self.base / "runtime"
+        self.runtime.mkdir()
+        self.archive = self.base / "archive"
+        self.archive.mkdir()
+        self.governance = self.base / "governance.json"
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def validate(self, **overrides) -> dict:
+        policy = {
+            "schema_version": 1,
+            "source_policy": {
+                "local_only_canonical_registry": str(self.registry),
+                "projection_roots": [str(self.runtime)],
+                "inventory_roots": [
+                    {
+                        "path": str(self.archive),
+                        "kind": "archive",
+                        "owner": "recovery-store",
+                    }
+                ],
+            },
+        }
+        policy.update(overrides)
+        self.governance.write_text(json.dumps(policy), encoding="utf-8")
+        return validator.validate_ecosystem(self.governance, run_loom=False)
+
+    def test_nested_archive_skills_are_discovered_without_container_errors(self) -> None:
+        write_skill(self.archive / "2026-07-14" / "pre-sync" / "saved-copy", "old-skill")
+        write_skill(self.archive / "trash-entry" / "skill", "retired-skill")
+
+        result = self.validate()
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["summary"]["instances"], 2)
+        self.assertEqual(result["summary"]["declared_names"], 2)
+        self.assertNotIn(
+            "directory_name_mismatch",
+            {finding["code"] for finding in result["findings"]},
+        )
+
+    def test_archived_retired_and_divergent_copies_do_not_become_active_errors(self) -> None:
+        write_skill(self.registry / "skills" / "current", "current", body="current")
+        write_skill(self.archive / "old" / "current", "current", body="old")
+        write_skill(
+            self.archive / "old" / "retired",
+            "retired",
+            body="Call retired again only when restoring this archive.",
+        )
+
+        result = self.validate(retired_skills=["retired"])
+        codes = {finding["code"] for finding in result["findings"]}
+
+        self.assertTrue(result["ok"])
+        self.assertNotIn("retired_skill_active", codes)
+        self.assertNotIn("retired_skill_reference", codes)
+        self.assertNotIn("registry_projection_content_conflict", codes)
+
+
+class ProjectProjectionGlobTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.base = Path(self.tempdir.name)
+        self.registry = self.base / "registry"
+        self.registry.joinpath("skills").mkdir(parents=True)
+        self.runtime = self.base / "runtime"
+        self.runtime.mkdir()
+        self.governance = self.base / "governance.json"
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def validate(self, pattern: str) -> dict:
+        policy = {
+            "schema_version": 1,
+            "source_policy": {
+                "local_only_canonical_registry": str(self.registry),
+                "projection_roots": [str(self.runtime)],
+                "projection_globs": [pattern],
+            },
+        }
+        self.governance.write_text(json.dumps(policy), encoding="utf-8")
+        return validator.validate_ecosystem(self.governance, run_loom=False)
+
+    def test_project_projection_glob_is_scanned_as_active(self) -> None:
+        source = write_skill(self.registry / "skills" / "project-skill", "project-skill")
+        project_root = self.base / "project-one" / ".codex" / "skills"
+        project_root.mkdir(parents=True)
+        (project_root / "project-skill").symlink_to(source, target_is_directory=True)
+
+        result = self.validate(str(self.base / "project-*" / ".codex" / "skills"))
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["summary"]["instances"], 2)
+        self.assertEqual(result["roots"]["project_projections"], [str(project_root)])
+
+    def test_project_projection_glob_must_match(self) -> None:
+        result = self.validate(str(self.base / "missing-*" / ".codex" / "skills"))
+
+        self.assertFalse(result["ok"])
+        self.assertIn(
+            "projection_glob_empty",
+            {finding["code"] for finding in result["findings"]},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Add regression coverage for repository roots, archives, project projection globs, canonical decisions, inventory roots, and composite materializations without replacing the production implementation merged in PR #146.

Closes #151

## Test Plan

- [x] targeted ecosystem suite — 63 passed, 6 subtests passed
- [x] `python3 -m py_compile skills/skill-ecosystem-doctor/scripts/*.py`
- [x] `python3 scripts/validate_skills.py --check` — 96 Skills, 0 errors
- [x] `python3 -m pytest -q` — 317 passed, 102 subtests passed
- [x] `git diff --check`