### PR TITLE
fix: ignore runtime agent metadata in audits

### DIFF
--- a/docs/skill-quality-playbook.md
+++ b/docs/skill-quality-playbook.md
@@ -115,7 +115,7 @@ Spellbook splits artifact checks into strict validation and advisory audit:
 | Tool | Level | Checks |
 |---|---|---|
 | `python3 scripts/validate_skills.py --check` | Strict | parseable frontmatter, matching non-empty `name` and `description`, duplicate names, generated registry drift, current README counts, missing local support files referenced from `SKILL.md`, unsafe support paths, and unresolved runtime placeholders such as `{SCRIPT}`, `{ARGS}`, `{ARGUMENTS}`, or `<TODO>`. |
-| `python3 scripts/audit_skill_quality.py` | Advisory | trigger wording, gotchas, verification cues, operating contract signals, progressive disclosure, unreferenced support directories, missing support files with actionable paths, legacy argument-token usage, and referenced scripts that are neither executable nor shebang-marked. |
+| `python3 scripts/audit_skill_quality.py` | Advisory | trigger wording, gotchas, verification cues, operating contract signals, progressive disclosure, unreferenced content support directories, missing support files with actionable paths, legacy argument-token usage, and referenced scripts that are neither executable nor shebang-marked. Product runtime metadata under `agents/` is excluded from the content-reference check. |
 
 Strict failures should block release or installation changes. Advisory findings
 should be reviewed in PRs and may be accepted when the skill is intentionally

--- a/scripts/audit_skill_quality.py
+++ b/scripts/audit_skill_quality.py
@@ -22,6 +22,9 @@ from skill_artifact_checks import (
 )
 from validate_skills import CATEGORY_BY_NAME, ROOT, SkillEntry, discover_skills, parse_frontmatter
 
+
+CONTENT_SUPPORT_DIR_NAMES = SUPPORT_DIR_NAMES - {"agents"}
+
 TRIGGER_CUES = (
     "use when",
     "use this skill",
@@ -140,7 +143,7 @@ def support_dirs_for(entry: SkillEntry) -> list[str]:
     return sorted(
         child.name
         for child in skill_dir.iterdir()
-        if child.is_dir() and child.name in SUPPORT_DIR_NAMES
+        if child.is_dir() and child.name in CONTENT_SUPPORT_DIR_NAMES
     )
 
 

--- a/tests/test_skill_artifact_checks.py
+++ b/tests/test_skill_artifact_checks.py
@@ -138,6 +138,21 @@ class SkillArtifactCheckTests(unittest.TestCase):
 
             self.assertTrue(any(finding.check == "script-reference" for finding in findings), findings)
 
+    def test_audit_treats_agents_directory_as_runtime_metadata(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            entry = write_skill(root, "fixture-skill", "Step\n" * 301)
+            metadata_file = root / "skills" / "fixture-skill" / "agents" / "openai.yaml"
+            metadata_file.parent.mkdir()
+            metadata_file.write_text("interface: {}\n", encoding="utf-8")
+
+            with patched_roots(root):
+                findings = audit_skill_quality.audit_entry(entry)
+
+            checks = {finding.check for finding in findings}
+            self.assertNotIn("support-reference", checks)
+            self.assertIn("progressive-disclosure", checks)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`agents/` contains product runtime metadata rather than progressively disclosed content. Exclude it only from the unreferenced content-support check and document the distinction.

Closes #153

## Test Plan

- [x] `python3 -m pytest -q tests/test_skill_artifact_checks.py` — 8 passed
- [x] `python3 -m py_compile scripts/*.py`
- [x] `python3 scripts/validate_skills.py --check` — 96 Skills, 0 errors
- [x] `python3 -m pytest -q` — 306 passed, 102 subtests passed
- [x] `git diff --check`